### PR TITLE
refactor: permissionsをClaude GitHub App前提の最小限に簡素化

### DIFF
--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -8,16 +8,10 @@ on:
 
 # Reusable workflows are constrained by the caller's permissions,
 # so they must be explicitly declared here.
+# Claude GitHub App manages its own token, so only minimal permissions are needed.
 permissions:
-  checks: read
   contents: read
-  discussions: read
   id-token: write
-  issues: read
-  pages: read
-  pull-requests: write
-  repository-projects: read
-  security-events: read
 
 jobs:
   kyosei:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -94,16 +94,12 @@ on:
         description: Anthropic API key (alternative to OAuth token)
         required: false
 
+# Claude GitHub App manages its own token, so only minimal permissions are needed.
+# If the caller passes github_token explicitly, additional permissions
+# (e.g. pull-requests: write) must be granted by the caller.
 permissions:
-  checks: read # Reference CI results
-  contents: read # Read repository contents for review
-  discussions: read # Reference discussions
-  id-token: write # Required for Claude Code Action
-  issues: read # Reference issues
-  pages: read # Reference existing documentation
-  pull-requests: write # Post review comments on PRs
-  repository-projects: read # Reference project schedules
-  security-events: read # Reference vulnerability reports
+  contents: read # Read repository contents for checkout
+  id-token: write # Required for Claude Code Action OIDC authentication
 
 jobs:
   kyosei:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -93,6 +93,11 @@ on:
       anthropic_api_key:
         description: Anthropic API key (alternative to OAuth token)
         required: false
+      github_token:
+        description: >-
+          GitHub token for API access.
+          If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
+        required: false
 
 # Claude GitHub App manages its own token, so only minimal permissions are needed.
 # If the caller passes github_token explicitly, additional permissions
@@ -114,6 +119,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          github_token: ${{ secrets.github_token }}
           model: ${{ inputs.model }}
           allowed_bots: ${{ inputs.allowed_bots }}
           allowed_tools: ${{ inputs.allowed_tools }}

--- a/README.md
+++ b/README.md
@@ -65,15 +65,8 @@ on:
 # Reusable workflows are constrained by the caller's permissions,
 # so they must be explicitly declared here.
 permissions:
-  checks: read # Reference CI results
-  contents: read # Read repository contents for review
-  discussions: read # Reference discussions
-  id-token: write # Required for Claude Code Action
-  issues: read # Reference issues
-  pages: read # Reference existing documentation
-  pull-requests: write # Post review comments on PRs
-  repository-projects: read # Reference project schedules
-  security-events: read # Reference vulnerability reports
+  contents: read # Read repository contents for checkout
+  id-token: write # Required for Claude Code Action OIDC authentication
 
 jobs:
   kyosei:
@@ -101,15 +94,8 @@ on:
     types: [opened, synchronize]
 
 permissions:
-  checks: read # Reference CI results
-  contents: read # Read repository contents for review
-  discussions: read # Reference discussions
-  id-token: write # Required for Claude Code Action
-  issues: read # Reference issues
-  pages: read # Reference existing documentation
-  pull-requests: write # Post review comments on PRs
-  repository-projects: read # Reference project schedules
-  security-events: read # Reference vulnerability reports
+  contents: read # Read repository contents for checkout
+  id-token: write # Required for Claude Code Action OIDC authentication
 
 jobs:
   review:
@@ -182,34 +168,17 @@ To add tools without replacing the defaults, use `additional_allowed_tools`:
 
 ## Permissions
 
-The following permissions are required:
+When `github_token` is omitted (default), Claude GitHub App manages its own token,
+so the workflow only needs minimal permissions:
 
 ```yaml
 permissions:
-  checks: read # Reference CI results
-  contents: read # Read repository contents for review
-  discussions: read # Reference discussions
-  id-token: write # Required for Claude Code Action
-  issues: read # Reference issues
-  pages: read # Reference existing documentation
-  pull-requests: write # Post review comments on PRs
-  repository-projects: read # Reference project schedules
-  security-events: read # Reference vulnerability reports
+  contents: read # Read repository contents for checkout
+  id-token: write # Required for Claude Code Action OIDC authentication
 ```
 
-The minimum permissions required to run are:
-
-```yaml
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: write
-```
-
-The other permissions allow the review agent to reference
-additional context (CI results, issues, discussions, etc.)
-for better review quality.
-
+If you explicitly pass `github_token`, the token needs additional permissions
+such as `pull-requests: write` for posting review comments.
 If the token lacks `pull-requests: write`
 (e.g. due to workflow file changes in the PR or fork PRs),
 the action will skip gracefully with a warning instead of failing.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ jobs:
 ```
 
 Most Composite Action inputs can be passed via `with:`.
-The Reusable Workflow additionally accepts `fetch-depth` and `timeout-minutes`,
-but does not expose `github_token` (it manages checkout and tokens internally).
+The Reusable Workflow additionally accepts `fetch-depth` and `timeout-minutes`.
 See the Composite Action section below for the full input list.
 
 ## Composite Action


### PR DESCRIPTION
github_tokenを省略するとclaude-code-actionがClaude GitHub Appのトークンを使うため、 ワークフローのpermissionsブロックが制約するgithub.tokenには最小限の権限があれば十分です。 github_tokenを明示する場合は呼び出し側で追加権限を付与する必要がある旨を記載しました。