### PR TITLE
fix(action): `github_token`を`custom_github_token`にリネーム

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -93,14 +93,14 @@ on:
       anthropic_api_key:
         description: Anthropic API key (alternative to OAuth token)
         required: false
-      github_token:
+      custom_github_token:
         description: >-
           GitHub token for API access.
           If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
         required: false
 
 # Claude GitHub App manages its own token, so only minimal permissions are needed.
-# If the caller passes github_token explicitly, additional permissions
+# If the caller passes custom_github_token explicitly, additional permissions
 # (e.g. pull-requests: write) must be granted by the caller.
 permissions:
   contents: read # Read repository contents for checkout
@@ -119,7 +119,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
-          github_token: ${{ secrets.github_token }}
+          custom_github_token: ${{ secrets.custom_github_token }}
           model: ${{ inputs.model }}
           allowed_bots: ${{ inputs.allowed_bots }}
           allowed_tools: ${{ inputs.allowed_tools }}

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ jobs:
 | `claude_code_oauth_token`  | Claude Code OAuth token                                 | No       |                                      |
 | `anthropic_api_key`        | Anthropic API key (alternative to OAuth token)          | No       |                                      |
 | `model`                    | Claude model to use                                     | No       | `opus[1m]`                           |
-| `custom_github_token`             | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
+| `custom_github_token`      | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
 | `allowed_bots`             | Allowed bot usernames or `*` for all                    | No       | `*`                                  |
 | `allowed_tools`            | Allowed tools (newline-separated, replaces default set) | No       | See below                            |
 | `additional_allowed_tools` | Additional tools to append (newline-separated)          | No       | `""`                                 |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ jobs:
 | `claude_code_oauth_token`  | Claude Code OAuth token                                 | No       |                                      |
 | `anthropic_api_key`        | Anthropic API key (alternative to OAuth token)          | No       |                                      |
 | `model`                    | Claude model to use                                     | No       | `opus[1m]`                           |
-| `github_token`             | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
+| `custom_github_token`             | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
 | `allowed_bots`             | Allowed bot usernames or `*` for all                    | No       | `*`                                  |
 | `allowed_tools`            | Allowed tools (newline-separated, replaces default set) | No       | See below                            |
 | `additional_allowed_tools` | Additional tools to append (newline-separated)          | No       | `""`                                 |
@@ -167,7 +167,7 @@ To add tools without replacing the defaults, use `additional_allowed_tools`:
 
 ## Permissions
 
-When `github_token` is omitted (default), Claude GitHub App manages its own token,
+When `custom_github_token` is omitted (default), Claude GitHub App manages its own token,
 so the workflow only needs minimal permissions:
 
 ```yaml
@@ -176,7 +176,7 @@ permissions:
   id-token: write # Required for Claude Code Action OIDC authentication
 ```
 
-If you explicitly pass `github_token`, the token needs additional permissions
+If you explicitly pass `custom_github_token`, the token needs additional permissions
 such as `pull-requests: write` for posting review comments.
 If the token lacks `pull-requests: write`
 (e.g. due to workflow file changes in the PR or fork PRs),

--- a/action.yml
+++ b/action.yml
@@ -25,11 +25,12 @@ inputs:
     default: "opus[1m]"
 
   # Claude Code Action pass-through
-  github_token:
+  custom_github_token:
     description: >-
       GitHub token for API access.
       If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
       Provide explicitly to use a custom token or github.token instead.
+      Named custom_github_token to avoid the reserved github_token input name.
     required: false
     default: ""
   allowed_bots:
@@ -179,7 +180,7 @@ runs:
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
-        github_token: ${{ inputs.github_token }} # Pass as-is (empty means claude-code-action uses Claude GitHub App token).
+        github_token: ${{ inputs.custom_github_token }} # Pass as-is (empty means claude-code-action uses Claude GitHub App token).
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}
         use_foundry: ${{ inputs.use_foundry }}


### PR DESCRIPTION
composite actionでは`github_token`が予約語として扱われるため、
別名にして回避しました。