### PR TITLE
fix: kyosei-actionの自己参照をタグベースに変更

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: ${{ inputs['fetch-depth'] }}
-      - uses: ncaq/kyosei-action@7b911d1c2dc95a699ce5d30d9a7e1c28503946e3 # v0.2.0
+      - uses: ncaq/kyosei-action@v0.2.0 # zizmor: ignore[unpinned-uses] self-reference; immutable releases make tag pinning safe
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ permissions:
 
 jobs:
   kyosei:
-    uses: ncaq/kyosei-action/.github/workflows/review.yml@7b911d1c2dc95a699ce5d30d9a7e1c28503946e3 # v0.2.0
+    uses: ncaq/kyosei-action/.github/workflows/review.yml@v0.2.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -83,7 +83,7 @@ See the Composite Action section below for the full input list.
 
 ### Usage
 
-Pinning by commit hash is recommended for security.
+Examples below use version tags. For stricter security, pin to a commit hash.
 
 ```yaml
 name: Kyosei
@@ -105,7 +105,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 50
-      - uses: ncaq/kyosei-action@7b911d1c2dc95a699ce5d30d9a7e1c28503946e3 # v0.2.0
+      - uses: ncaq/kyosei-action@v0.2.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -150,7 +150,7 @@ allowed_tools: |
 To add tools without replacing the defaults, use `additional_allowed_tools`:
 
 ```yaml
-- uses: ncaq/kyosei-action@7b911d1c2dc95a699ce5d30d9a7e1c28503946e3 # v0.2.0
+- uses: ncaq/kyosei-action@v0.2.0
   with:
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     additional_allowed_tools: |


### PR DESCRIPTION
ハッシュベースだとリリースのたびに鶏と卵の問題が発生するため、
タグベースに変更しました。
immutableリリースを使用しているためタグ参照でも安全です。
ハッシュでのピン留めはユーザの責任としてREADMEに記載しています。