### PR TITLE
ci: zizmorのpedanticモードでの警告にできる限り対応

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,10 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: daily
     labels:
       - "Type: CI"
       - "Type: Dependencies"
-    schedule:
-      interval: daily

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
   merge_group:
 
-permissions:
-  contents: read # リポジトリコンテンツの読み取り
-  id-token: write # niks3 OIDC認証
+permissions: {}
 
 jobs:
   nix-fast-build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # リポジトリコンテンツの読み取り
+      id-token: write # niks3 OIDC認証
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   nix-fast-build:
+    name: nix-fast-build
     runs-on: ubuntu-24.04
     permissions:
       contents: read # リポジトリコンテンツの読み取り

--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -6,15 +6,16 @@ on:
     # on the same revision from ready_for_review or reopened events.
     types: [opened, synchronize]
 
-# Reusable workflows are constrained by the caller's permissions,
-# so they must be explicitly declared here.
-# Claude GitHub App manages its own token, so only minimal permissions are needed.
-permissions:
-  contents: read # Read repository contents for checkout
-  id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
+permissions: {}
 
 jobs:
   kyosei:
+    # Reusable workflows are constrained by the caller's permissions,
+    # so they must be explicitly declared here.
+    # Claude GitHub App manages its own token, so only minimal permissions are needed.
+    permissions:
+      contents: read # Read repository contents for checkout
+      id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
     uses: ./.github/workflows/review.yml
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,13 @@ on:
     types: [completed]
     branches: [master, main]
 
-permissions:
-  contents: write # タグ作成のため
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # タグ作成のため
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions: {}
 
 jobs:
   release:
+    name: release
     runs-on: ubuntu-24.04
     permissions:
       contents: write # タグ作成のため

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -99,16 +99,17 @@ on:
           If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
         required: false
 
-# Claude GitHub App manages its own token, so only minimal permissions are needed.
-# If the caller passes custom_github_token explicitly, additional permissions
-# (e.g. pull-requests: write) must be granted by the caller.
-permissions:
-  contents: read # Read repository contents for checkout
-  id-token: write # Required for Claude Code Action OIDC authentication
+permissions: {}
 
 jobs:
   kyosei:
     runs-on: ubuntu-24.04
+    # Claude GitHub App manages its own token, so only minimal permissions are needed.
+    # If the caller passes custom_github_token explicitly, additional permissions
+    # (e.g. pull-requests: write) must be granted by the caller.
+    permissions:
+      contents: read # Read repository contents for checkout
+      id-token: write # Required for Claude Code Action OIDC authentication
     timeout-minutes: ${{ inputs['timeout-minutes'] }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -103,6 +103,7 @@ permissions: {}
 
 jobs:
   kyosei:
+    name: kyosei
     runs-on: ubuntu-24.04
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -101,6 +101,13 @@ on:
 
 permissions: {}
 
+# Cancel previous runs on the same PR to avoid stale reviews.
+# The review agent reads the current PR state, so concurrent runs
+# on different revisions would produce inconsistent results.
+concurrency:
+  group: kyosei-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   kyosei:
     name: kyosei

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  concurrency-limits:
+    ignore:
+      - check.yml # 連続pushでも全て検査したいためconcurrency制限は不要

--- a/README.md
+++ b/README.md
@@ -62,15 +62,16 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-# Reusable workflows are constrained by the caller's permissions,
-# so they must be explicitly declared here.
-# Claude GitHub App manages its own token, so only minimal permissions are needed.
-permissions:
-  contents: read # Read repository contents for checkout
-  id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
+permissions: {}
 
 jobs:
   kyosei:
+    # Reusable workflows are constrained by the caller's permissions,
+    # so they must be explicitly declared here.
+    # Claude GitHub App manages its own token, so only minimal permissions are needed.
+    permissions:
+      contents: read # Read repository contents for checkout
+      id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
     uses: ncaq/kyosei-action/.github/workflows/review.yml@v0.2.1
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -93,14 +94,15 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-# Claude GitHub App manages its own token, so only minimal permissions are needed.
-permissions:
-  contents: read # Read repository contents for checkout
-  id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
+permissions: {}
 
 jobs:
   review:
     runs-on: ubuntu-24.04
+    # Claude GitHub App manages its own token, so only minimal permissions are needed.
+    permissions:
+      contents: read # Read repository contents for checkout
+      id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -170,7 +172,7 @@ To add tools without replacing the defaults, use `additional_allowed_tools`:
 ## Permissions
 
 When `custom_github_token` is omitted (default), Claude GitHub App manages its own token,
-so the workflow only needs minimal permissions:
+so each job only needs minimal permissions:
 
 ```yaml
 permissions:

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
                 command = pkgs.editorconfig-checker;
                 includes = [ "*" ];
               };
+              zizmor.options = [ "--pedantic" ];
             };
           };
           packages = {


### PR DESCRIPTION
- **ci: Dependabotに`cooldown`設定を追加**
- **ci: zizmorを`--pedantic`モードに変更**
- **ci: `permissions`をworkflow-levelからjob-levelに移動**
- **ci: jobに`name`を追加**
- **ci: `concurrency-limits`監査に対応**
- **docs: READMEのサンプルを`permissions`のjob-level化に合わせて更新**
