### PR TITLE
ci: GitHub UIでのチェック表示名を改善

### DIFF
--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 jobs:
-  kyosei:
+  workflow:
     # Reusable workflows are constrained by the caller's permissions,
     # so they must be explicitly declared here.
     # Claude GitHub App manages its own token, so only minimal permissions are needed.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,4 +1,4 @@
-name: Kyosei
+name: Kyosei Review
 
 on:
   workflow_call:
@@ -110,7 +110,7 @@ concurrency:
 
 jobs:
   kyosei:
-    name: kyosei
+    name: review
     runs-on: ubuntu-24.04
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ on:
 permissions: {}
 
 jobs:
-  kyosei:
+  workflow:
     # Reusable workflows are constrained by the caller's permissions,
     # so they must be explicitly declared here.
     # Claude GitHub App manages its own token, so only minimal permissions are needed.


### PR DESCRIPTION
呼び出し側のステータス表示で、
`Kyosei / kyosei / kyosei`と同じ単語が3つ並んで分かりにくかったため、
`Kyosei / workflow / review`となるように変更しました。
各階層がワークフロー名/呼び出しjob/実行jobと区別できるようになります。
まだ利用者が自分しか居ないはずなのでjob idの破壊的変更は全く気にしていません。

- kyosei.ymlのjob IDを`kyosei`→`workflow`に変更
- review.ymlのworkflow名を`Kyosei`→`Kyosei Review`に変更
- review.ymlのjob nameを`kyosei`→`review`に変更
