### PR TITLE
feat: Reusable Workflowに`runs-on` inputを追加

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -71,6 +71,16 @@ on:
         type: string
         required: false
         default: "kyosei@konoka"
+      runs-on:
+        description: Runner label for the job (e.g. a self-hosted runner label).
+        type: string
+        required: false
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: Job timeout in minutes. Set as a safeguard against hangs.
+        type: number
+        required: false
+        default: 30
       fetch-depth:
         description: >-
           Number of commits to fetch.
@@ -78,11 +88,6 @@ on:
         type: number
         required: false
         default: 50
-      timeout-minutes:
-        description: Job timeout in minutes. Set as a safeguard against hangs.
-        type: number
-        required: false
-        default: 30
     # At least one secret is required.
     # Typically only one is needed.
     # If multiple are provided they are passed through to claude-code-action as-is.
@@ -111,7 +116,7 @@ concurrency:
 jobs:
   kyosei:
     name: review
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runs-on }}
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions
     # (e.g. pull-requests: write) must be granted by the caller.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -119,7 +119,7 @@ concurrency:
 jobs:
   kyosei:
     name: review
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ fromJSON(inputs['runs-on']) }}
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions
     # (e.g. pull-requests: write) must be granted by the caller.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -72,10 +72,13 @@ on:
         required: false
         default: "kyosei@konoka"
       runs-on:
-        description: Runner label for the job (e.g. a self-hosted runner label).
+        description: >-
+          Runner label(s) for the job. Must be a valid JSON value because it is parsed with fromJSON().
+          A single label ("ubuntu-24.04") or an array (["self-hosted", "linux"]) are both accepted.
+          Note: bare strings without quotes (e.g. ubuntu-24.04) will fail.
         type: string
         required: false
-        default: "ubuntu-24.04"
+        default: '"ubuntu-24.04"'
       timeout-minutes:
         description: Job timeout in minutes. Set as a safeguard against hangs.
         type: number
@@ -116,7 +119,7 @@ concurrency:
 jobs:
   kyosei:
     name: review
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions
     # (e.g. pull-requests: write) must be granted by the caller.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,14 @@ jobs:
 ```
 
 Most Composite Action inputs can be passed via `with:`.
-The Reusable Workflow additionally accepts `fetch-depth` and `timeout-minutes`.
+The Reusable Workflow additionally accepts the following inputs:
+
+| Name              | Description                | Default        |
+| ----------------- | -------------------------- | -------------- |
+| `runs-on`         | Runner label for the job   | `ubuntu-24.04` |
+| `timeout-minutes` | Job timeout in minutes     | `30`           |
+| `fetch-depth`     | Number of commits to fetch | `50`           |
+
 See the Composite Action section below for the full input list.
 
 ## Composite Action

--- a/README.md
+++ b/README.md
@@ -80,11 +80,24 @@ jobs:
 Most Composite Action inputs can be passed via `with:`.
 The Reusable Workflow additionally accepts the following inputs:
 
-| Name              | Description                | Default        |
-| ----------------- | -------------------------- | -------------- |
-| `runs-on`         | Runner label for the job   | `ubuntu-24.04` |
-| `timeout-minutes` | Job timeout in minutes     | `30`           |
-| `fetch-depth`     | Number of commits to fetch | `50`           |
+| Name              | Description                | Default          |
+| ----------------- | -------------------------- | ---------------- |
+| `runs-on`         | Runner label(s) as JSON    | `"ubuntu-24.04"` |
+| `timeout-minutes` | Job timeout in minutes     | `30`             |
+| `fetch-depth`     | Number of commits to fetch | `50`             |
+
+`runs-on` is parsed with `fromJSON()`, so the value must be valid JSON.
+YAML double quotes are stripped by the YAML parser, so you need to nest JSON quotes inside YAML single quotes:
+
+```yaml
+# Single label
+with:
+  runs-on: '"ubuntu-24.04"'
+
+# Multiple labels
+with:
+  runs-on: '["self-hosted", "linux"]'
+```
 
 See the Composite Action section below for the full input list.
 


### PR DESCRIPTION
セルフホストランナーを使用したいユーザ向けに、
ランナーラベルを指定できるようにしました。
デフォルトは`ubuntu-24.04`です。

合わせてinputの並び順を整理し、
`fetch-depth`をワークフロー設定系の末尾に移動しました。
