### PR TITLE
refactor: inputsを論理的なグループ順に並び替え

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,12 +2,41 @@ name: Kyosei Review
 
 on:
   workflow_call:
-    inputs:
-      model:
-        description: Claude model to use
-        type: string
+    # At least one secret is required.
+    # Typically only one is needed.
+    # If multiple are provided they are passed through to claude-code-action as-is.
+    secrets:
+      claude_code_oauth_token:
+        description: Claude Code OAuth token
         required: false
-        default: "opus[1m]"
+      anthropic_api_key:
+        description: Anthropic API key (alternative to OAuth token)
+        required: false
+      custom_github_token:
+        description: >-
+          GitHub token for API access.
+          If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
+        required: false
+
+    inputs:
+      # Authentication
+      use_bedrock:
+        description: Use Amazon Bedrock with OIDC authentication
+        type: boolean
+        required: false
+        default: false
+      use_vertex:
+        description: Use Google Vertex AI with OIDC authentication
+        type: boolean
+        required: false
+        default: false
+      use_foundry:
+        description: Use Microsoft Foundry with OIDC authentication
+        type: boolean
+        required: false
+        default: false
+
+      # Claude Code Action pass-through
       allowed_bots:
         description: >-
           Comma-separated list of allowed bot usernames, or '*' to allow all bots.
@@ -15,6 +44,13 @@ on:
         type: string
         required: false
         default: "*"
+
+      # Claude Code configuration
+      model:
+        description: Claude model to use
+        type: string
+        required: false
+        default: "opus[1m]"
       allowed_tools:
         description: >-
           Allowed tools for Claude Code (newline-separated, replaces default set).
@@ -46,23 +82,10 @@ on:
         type: string
         required: false
         default: ""
-      use_bedrock:
-        description: Use Amazon Bedrock with OIDC authentication
-        type: boolean
-        required: false
-        default: false
-      use_vertex:
-        description: Use Google Vertex AI with OIDC authentication
-        type: boolean
-        required: false
-        default: false
-      use_foundry:
-        description: Use Microsoft Foundry with OIDC authentication
-        type: boolean
-        required: false
-        default: false
-      konoka_marketplace_url:
-        description: Git URL of the Konoka marketplace
+
+      # Marketplace and plugin
+      marketplace_url:
+        description: Git URL of the plugin marketplace
         type: string
         required: false
         default: "https://github.com/ncaq/konoka.git"
@@ -71,6 +94,8 @@ on:
         type: string
         required: false
         default: "kyosei@konoka"
+
+      # Workflow configuration
       runs-on:
         description: >-
           Runner label(s) for the job. Must be a valid JSON value because it is parsed with fromJSON().
@@ -91,21 +116,6 @@ on:
         type: number
         required: false
         default: 50
-    # At least one secret is required.
-    # Typically only one is needed.
-    # If multiple are provided they are passed through to claude-code-action as-is.
-    secrets:
-      claude_code_oauth_token:
-        description: Claude Code OAuth token
-        required: false
-      anthropic_api_key:
-        description: Anthropic API key (alternative to OAuth token)
-        required: false
-      custom_github_token:
-        description: >-
-          GitHub token for API access.
-          If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
-        required: false
 
 permissions: {}
 
@@ -136,14 +146,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
-          custom_github_token: ${{ secrets.custom_github_token }}
-          model: ${{ inputs.model }}
-          allowed_bots: ${{ inputs.allowed_bots }}
-          allowed_tools: ${{ inputs.allowed_tools }}
-          additional_allowed_tools: ${{ inputs.additional_allowed_tools }}
-          claude_args: ${{ inputs.claude_args }}
           use_bedrock: ${{ inputs.use_bedrock && 'true' || 'false' }}
           use_vertex: ${{ inputs.use_vertex && 'true' || 'false' }}
           use_foundry: ${{ inputs.use_foundry && 'true' || 'false' }}
-          konoka_marketplace_url: ${{ inputs.konoka_marketplace_url }}
+          custom_github_token: ${{ secrets.custom_github_token }}
+          allowed_bots: ${{ inputs.allowed_bots }}
+          model: ${{ inputs.model }}
+          allowed_tools: ${{ inputs.allowed_tools }}
+          additional_allowed_tools: ${{ inputs.additional_allowed_tools }}
+          claude_args: ${{ inputs.claude_args }}
+          marketplace_url: ${{ inputs.marketplace_url }}
           plugin_name: ${{ inputs.plugin_name }}

--- a/README.md
+++ b/README.md
@@ -140,16 +140,16 @@ jobs:
 | -------------------------- | ------------------------------------------------------- | -------- | ------------------------------------ |
 | `claude_code_oauth_token`  | Claude Code OAuth token                                 | No       |                                      |
 | `anthropic_api_key`        | Anthropic API key (alternative to OAuth token)          | No       |                                      |
-| `model`                    | Claude model to use                                     | No       | `opus[1m]`                           |
-| `custom_github_token`      | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
-| `allowed_bots`             | Allowed bot usernames or `*` for all                    | No       | `*`                                  |
-| `allowed_tools`            | Allowed tools (newline-separated, replaces default set) | No       | See below                            |
-| `additional_allowed_tools` | Additional tools to append (newline-separated)          | No       | `""`                                 |
-| `claude_args`              | Additional CLI arguments                                | No       | `""`                                 |
 | `use_bedrock`              | Use Amazon Bedrock with OIDC                            | No       | `false`                              |
 | `use_vertex`               | Use Google Vertex AI with OIDC                          | No       | `false`                              |
 | `use_foundry`              | Use Microsoft Foundry with OIDC                         | No       | `false`                              |
-| `konoka_marketplace_url`   | Git URL of the Konoka marketplace                       | No       | `https://github.com/ncaq/konoka.git` |
+| `custom_github_token`      | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
+| `allowed_bots`             | Allowed bot usernames or `*` for all                    | No       | `*`                                  |
+| `model`                    | Claude model to use                                     | No       | `opus[1m]`                           |
+| `allowed_tools`            | Allowed tools (newline-separated, replaces default set) | No       | See below                            |
+| `additional_allowed_tools` | Additional tools to append (newline-separated)          | No       | `""`                                 |
+| `claude_args`              | Additional CLI arguments                                | No       | `""`                                 |
+| `marketplace_url`          | Git URL of the plugin marketplace                       | No       | `https://github.com/ncaq/konoka.git` |
 | `plugin_name`              | Plugin identifier within the marketplace                | No       | `kyosei@konoka`                      |
 
 #### Default allowed tools

--- a/action.yml
+++ b/action.yml
@@ -18,14 +18,18 @@ inputs:
     description: Anthropic API key (alternative to OAuth token)
     required: false
     default: ""
-
-  # Model configuration
-  model:
-    description: Claude model to use
+  use_bedrock:
+    description: Use Amazon Bedrock with OIDC authentication
     required: false
-    default: "opus[1m]"
-
-  # Claude Code Action pass-through
+    default: "false"
+  use_vertex:
+    description: Use Google Vertex AI with OIDC authentication
+    required: false
+    default: "false"
+  use_foundry:
+    description: Use Microsoft Foundry with OIDC authentication
+    required: false
+    default: "false"
   custom_github_token:
     description: >-
       GitHub token for API access.
@@ -34,12 +38,20 @@ inputs:
       Named custom_github_token to avoid the reserved github_token input name.
     required: false
     default: ""
+
+  # Claude Code Action pass-through
   allowed_bots:
     description: >-
       Comma-separated list of allowed bot usernames, or '*' to allow all bots.
       Defaults to '*' because bots are not inherently more dangerous than humans.
     required: false
     default: "*"
+
+  # Claude Code configuration
+  model:
+    description: Claude model to use
+    required: false
+    default: "opus[1m]"
   allowed_tools:
     description: >-
       Allowed tools for Claude Code (newline-separated, replaces default set).
@@ -68,22 +80,10 @@ inputs:
     description: Additional arguments to pass to Claude CLI (appended after --model and --allowed-tools)
     required: false
     default: ""
-  use_bedrock:
-    description: Use Amazon Bedrock with OIDC authentication
-    required: false
-    default: "false"
-  use_vertex:
-    description: Use Google Vertex AI with OIDC authentication
-    required: false
-    default: "false"
-  use_foundry:
-    description: Use Microsoft Foundry with OIDC authentication
-    required: false
-    default: "false"
 
-  # Kyosei-specific
-  konoka_marketplace_url:
-    description: Git URL of the Konoka marketplace
+  # Marketplace and plugin
+  marketplace_url:
+    description: Git URL of the plugin marketplace
     required: false
     default: "https://github.com/ncaq/konoka.git"
   plugin_name:
@@ -110,7 +110,7 @@ runs:
         USE_BEDROCK: ${{ inputs.use_bedrock }}
         USE_VERTEX: ${{ inputs.use_vertex }}
         USE_FOUNDRY: ${{ inputs.use_foundry }}
-        KONOKA_MARKETPLACE_URL: ${{ inputs.konoka_marketplace_url }}
+        MARKETPLACE_URL: ${{ inputs.marketplace_url }}
         PLUGIN_NAME: ${{ inputs.plugin_name }}
         MODEL: ${{ inputs.model }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -145,12 +145,12 @@ runs:
 
         echo "Model: $MODEL"
         echo "Plugin: $PLUGIN_NAME"
-        echo "Marketplace: $KONOKA_MARKETPLACE_URL"
+        echo "Marketplace: $MARKETPLACE_URL"
         echo "PR: #$PR_NUMBER"
 
         # Marketplace URL must end with .git (required by claude-code-action).
-        if [[ -n "$KONOKA_MARKETPLACE_URL" && "$KONOKA_MARKETPLACE_URL" != *.git ]]; then
-          errors+=("konoka_marketplace_url must end with '.git': $KONOKA_MARKETPLACE_URL")
+        if [[ -n "$MARKETPLACE_URL" && "$MARKETPLACE_URL" != *.git ]]; then
+          errors+=("marketplace_url must end with '.git': $MARKETPLACE_URL")
         fi
 
         # Plugin name must not be empty.
@@ -202,18 +202,18 @@ runs:
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
-        github_token: ${{ inputs.custom_github_token }} # Pass as-is (empty means claude-code-action uses Claude GitHub App token).
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}
         use_foundry: ${{ inputs.use_foundry }}
-        plugin_marketplaces: ${{ inputs.konoka_marketplace_url }}
-        plugins: ${{ inputs.plugin_name }}
-        prompt: "/kyosei REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}"
+        github_token: ${{ inputs.custom_github_token }} # Pass as-is (empty means claude-code-action uses Claude GitHub App token).
         allowed_bots: ${{ inputs.allowed_bots }}
         claude_args: >-
           --model "${{ inputs.model }}"
           --allowed-tools "${{ steps.build-allowed-tools.outputs.joined }}"
           ${{ inputs.claude_args }}
+        plugin_marketplaces: ${{ inputs.marketplace_url }}
+        plugins: ${{ inputs.plugin_name }}
+        prompt: "/kyosei REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}"
 
     # If claude-code-action fails, emit a warning instead of failing the workflow.
     # Common causes: insufficient token permissions (e.g. workflow file changes


### PR DESCRIPTION
inputs/secrets/withの並び順を以下のグループ順に統一しました。
1. 認証系(secrets, OAuth, API key, クラウドプロバイダ, GitHub token)
2. claude-code-action動作設定(`allowed_bots`)
3. Claude Code設定(`model`, `allowed_tools`, `claude_args`)
4. マーケットプレイス/プラグイン
5. ワークフロー設定(review.ymlのみ: `runs-on`, `timeout-minutes`, `fetch-depth`)

合わせて`konoka_marketplace_url`を`marketplace_url`に改名しました。
`plugin_name`は汎用的な名前なのに`konoka_marketplace_url`だけ固有名を含んでいたためです。
