### PR TITLE
feat: セルフホストランナー向けパッケージ自動インストールを追加

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -117,6 +117,20 @@ on:
         required: false
         default: 50
 
+      # Self-hosted runner support
+      self_hosted_packages:
+        description: >-
+          Newline-separated list of packages to install via apt-get on self-hosted runners.
+          Installation runs only when the runner environment is "self-hosted".
+          Set to an empty string to skip installation entirely.
+        type: string
+        required: false
+        default: |
+          curl
+          gh
+          git
+          zstd
+
 permissions: {}
 
 # Cancel previous runs on the same PR to avoid stale reviews.
@@ -138,6 +152,16 @@ jobs:
       id-token: write # Required for Claude Code Action OIDC authentication
     timeout-minutes: ${{ inputs['timeout-minutes'] }}
     steps:
+      - name: Install packages for self-hosted runner
+        if: runner.environment == 'self-hosted' && inputs.self_hosted_packages != ''
+        env:
+          PACKAGES: ${{ inputs.self_hosted_packages }}
+        shell: bash
+        run: |
+          sudo apt-get update -qq
+          # Convert newline-separated list to a bash array, then install.
+          mapfile -t pkgs < <(echo "$PACKAGES" | sed '/^[[:space:]]*$/d')
+          sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -129,11 +129,37 @@ jobs:
 Most Composite Action inputs can be passed via `with:`.
 The Reusable Workflow additionally accepts the following inputs:
 
-| Name              | Description                | Default          |
-| ----------------- | -------------------------- | ---------------- |
-| `runs-on`         | Runner label(s) as JSON    | `"ubuntu-24.04"` |
-| `timeout-minutes` | Job timeout in minutes     | `30`             |
-| `fetch-depth`     | Number of commits to fetch | `50`             |
+| Name                   | Description                                                                | Default          |
+| ---------------------- | -------------------------------------------------------------------------- | ---------------- |
+| `runs-on`              | Runner label(s) as JSON                                                    | `"ubuntu-24.04"` |
+| `timeout-minutes`      | Job timeout in minutes                                                     | `30`             |
+| `fetch-depth`          | Number of commits to fetch                                                 | `50`             |
+| `self_hosted_packages` | Packages to install via apt-get on self-hosted runners (newline-separated) | See below        |
+
+### Self-hosted runners
+
+When `runner.environment` is `self-hosted` and `self_hosted_packages` is non-empty,
+the workflow automatically installs the listed packages via `apt-get` before checkout.
+The default list covers the minimum programs required by kyosei-action and claude-code-action:
+
+```yaml
+self_hosted_packages: |
+  curl
+  gh
+  git
+  zstd
+```
+
+To skip automatic installation, pass an empty string:
+
+```yaml
+with:
+  self_hosted_packages: ""
+```
+
+On GitHub-hosted runners this step is always skipped regardless of the input value.
+
+### `runs-on` format
 
 `runs-on` is parsed with `fromJSON()`, so the value must be valid JSON.
 YAML double quotes are stripped by the YAML parser, so you need to nest JSON quotes inside YAML single quotes:


### PR DESCRIPTION
`runner.environment`が`self-hosted`の場合、
checkoutの前に`apt-get`で必要なパッケージを自動インストールするステップを追加しました。
デフォルトではcurl, gh, git, zstdをインストールします。
`self_hosted_packages`入力を空文字列にすることでスキップも可能です。

close #25
