### PR TITLE
build: konokaをv3.1.2に更新し、`nix fmt`フックを削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,7 @@
     "kyosei@konoka": true,
     "nix-tasuke@konoka": true
   },
+  "enableAllProjectMcpServers": true,
   "permissions": {
     "additionalDirectories": ["~/Desktop/konoka"],
     "allow": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,6 +83,5 @@
       "mcp__github__search_users",
       "mcp__nixos"
     ]
-  },
-  "hooks": {}
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "source": {
         "source": "github",
         "repo": "ncaq/konoka",
-        "ref": "v2.1.0"
+        "ref": "v3.1.2"
       }
     }
   },
@@ -83,18 +83,5 @@
       "mcp__nixos"
     ]
   },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Stop",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cd $CLAUDE_PROJECT_DIR && nix fmt",
-            "timeout": 30
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,34 +22,23 @@ ASCIIに対応する全角形(Fullwidth Forms)は使用禁止。
 
 ## フォーマット
 
-基本的にファイルはツールで自動フォーマットしています。
-
-### nix fmt
-
-[treefmt-nix](https://github.com/numtide/treefmt-nix)が対応しているファイルは以下のコマンドでフォーマット出来ます。
+nix fmtでフォーマットとリントを実行できます。
 
 ```console
 nix fmt
 ```
 
-Stopフックで`nix fmt`が自動実行されます。
+[nix-tasuke](https://github.com/ncaq/konoka/tree/master/plugins/nix-tasuke)プラグインにより、
+Claudeの応答完了時にStopフックで`nix fmt`が自動実行されます。
 ファイルの差分が出ることがあります。
 
 ## 統合チェック
 
-以下のコマンドでプロジェクト全体のチェックが行えます。
-フォーマットやリントやテストなどがまとめて実行されます。
+nix-fast-buildコマンドで統合チェックを実行できます。
 
 ```console
 nix-fast-build --option eval-cache false --no-link --skip-cached --no-nom
 ```
-
-`nix-fast-build`は`nix-eval-jobs`を使って`checks`を並列評価・ビルドします。
-`nix flake check`と比べて、
-評価が並列化されるため高速です。
-
-`--no-nom`オプションはnix-output-monitorを無効にしてシンプルなビルドログを出力します。
-LLMエージェントやCI環境などターミナル制御が貧弱な環境で使用してください。
 
 # リポジトリ構成
 


### PR DESCRIPTION
konokaのバージョンをv2.1.0からv3.1.2に更新しました。
また、Stopフックの`nix fmt`自動実行はkonoka側に同等の機能が含まれているため削除しました。
