### PR TITLE
build(deps): konokaをv4.0.0に更新しPRレビュー引数をURL形式に移行

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "source": {
         "source": "github",
         "repo": "ncaq/konoka",
-        "ref": "v3.1.2"
+        "ref": "v4.0.0"
       }
     }
   },

--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,7 @@ runs:
           ${{ inputs.claude_args }}
         plugin_marketplaces: ${{ inputs.marketplace_url }}
         plugins: ${{ inputs.plugin_name }}
-        prompt: "/kyosei REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}"
+        prompt: "/kyosei ${{ github.event.pull_request.html_url }}"
 
     # If claude-code-action fails, emit a warning instead of failing the workflow.
     # Common causes: insufficient token permissions (e.g. workflow file changes


### PR DESCRIPTION
konoka v4.0.0の破壊的変更に対応しました。
kyoseiスキルのPRレビュー引数が独自の`REPO:`/`PR_NUMBER:`形式から、
GitHub PRのURLをそのまま渡す形式に変更されています。
`github.event.pull_request.html_url`を使用することでURL組み立ても不要になりました。
