### PR TITLE
feat: claude-code-actionのレビュー関連オプションをパススルー追加

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,6 +16,7 @@ on:
         description: >-
           GitHub token for API access.
           If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
+          Provide explicitly to use a custom token or github.token instead.
         required: false
 
     inputs:
@@ -48,6 +49,7 @@ on:
         description: >-
           Comma-separated list of users without write permission who are allowed to trigger Claude,
           or '*' to allow all. Only works when custom_github_token is provided.
+          Enables bubblewrap sandbox and env scrubbing for safety.
         type: string
         required: false
         default: ""
@@ -68,13 +70,15 @@ on:
       additional_permissions:
         description: >-
           Additional GitHub permissions for the App token (newline-separated 'key: value').
-          Only effective with OIDC token exchange.
+          Example: 'actions: read' enables CI/CD failure analysis.
+          Only effective with OIDC token exchange (ignored when custom_github_token is set).
         type: string
         required: false
         default: ""
       settings:
         description: >-
           Claude Code settings as a JSON string or path to a JSON file.
+          Merged with existing settings (input takes precedence).
           Can configure hooks, env, MCP settings, etc.
         type: string
         required: false
@@ -113,7 +117,7 @@ on:
         required: false
         default: ""
       claude_args:
-        description: Additional arguments to pass to Claude CLI
+        description: Additional arguments to pass to Claude CLI (appended after --model and --allowed-tools)
         type: string
         required: false
         default: ""
@@ -135,7 +139,7 @@ on:
       show_full_output:
         description: >-
           Show full Claude Code JSON output in Actions logs.
-          May contain secrets; use only for debugging.
+          May contain secrets in tool results; use only for debugging.
           Ignored on public repositories to prevent secret leakage.
         type: boolean
         required: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -136,6 +136,7 @@ on:
         description: >-
           Show full Claude Code JSON output in Actions logs.
           May contain secrets; use only for debugging.
+          Ignored on public repositories to prevent secret leakage.
         type: boolean
         required: false
         default: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -133,6 +133,7 @@ on:
           Display Claude Code Report in GitHub Step Summary.
           Useful for understanding what Claude did during the review.
           "auto" (default) enables it only for private repositories.
+          Can be explicitly set to "true" on public repositories if secrets are properly managed.
         type: string
         required: false
         default: "auto"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -44,6 +44,41 @@ on:
         type: string
         required: false
         default: "*"
+      allowed_non_write_users:
+        description: >-
+          Comma-separated list of users without write permission who are allowed to trigger Claude,
+          or '*' to allow all. Only works when custom_github_token is provided.
+        type: string
+        required: false
+        default: ""
+      include_comments_by_actor:
+        description: >-
+          Filter to include only comments from specific actors.
+          Supports wildcards (e.g. '*[bot]'). Empty means include all.
+        type: string
+        required: false
+        default: ""
+      exclude_comments_by_actor:
+        description: >-
+          Filter to exclude comments from specific actors.
+          Supports wildcards. Exclusion takes precedence over inclusion.
+        type: string
+        required: false
+        default: ""
+      additional_permissions:
+        description: >-
+          Additional GitHub permissions for the App token (newline-separated 'key: value').
+          Only effective with OIDC token exchange.
+        type: string
+        required: false
+        default: ""
+      settings:
+        description: >-
+          Claude Code settings as a JSON string or path to a JSON file.
+          Can configure hooks, env, MCP settings, etc.
+        type: string
+        required: false
+        default: ""
 
       # Claude Code configuration
       model:
@@ -82,6 +117,28 @@ on:
         type: string
         required: false
         default: ""
+
+      # UI control
+      include_fix_links:
+        description: Include 'Fix this' deep links in PR review feedback
+        type: boolean
+        required: false
+        default: true
+      display_report:
+        description: >-
+          Display Claude Code Report in GitHub Step Summary.
+          Useful for understanding what Claude did during the review.
+          "auto" (default) enables it only for private repositories.
+        type: string
+        required: false
+        default: "auto"
+      show_full_output:
+        description: >-
+          Show full Claude Code JSON output in Actions logs.
+          May contain secrets; use only for debugging.
+        type: boolean
+        required: false
+        default: false
 
       # Marketplace and plugin
       marketplace_url:
@@ -175,9 +232,17 @@ jobs:
           use_foundry: ${{ inputs.use_foundry && 'true' || 'false' }}
           custom_github_token: ${{ secrets.custom_github_token }}
           allowed_bots: ${{ inputs.allowed_bots }}
+          allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+          include_comments_by_actor: ${{ inputs.include_comments_by_actor }}
+          exclude_comments_by_actor: ${{ inputs.exclude_comments_by_actor }}
+          additional_permissions: ${{ inputs.additional_permissions }}
+          settings: ${{ inputs.settings }}
           model: ${{ inputs.model }}
           allowed_tools: ${{ inputs.allowed_tools }}
           additional_allowed_tools: ${{ inputs.additional_allowed_tools }}
           claude_args: ${{ inputs.claude_args }}
+          include_fix_links: ${{ inputs.include_fix_links && 'true' || 'false' }}
+          display_report: ${{ inputs.display_report }}
+          show_full_output: ${{ inputs.show_full_output && 'true' || 'false' }}
           marketplace_url: ${{ inputs.marketplace_url }}
           plugin_name: ${{ inputs.plugin_name }}

--- a/README.md
+++ b/README.md
@@ -213,29 +213,162 @@ jobs:
 
 ### Inputs
 
-| Name                        | Description                                                             | Required | Default                              |
-| --------------------------- | ----------------------------------------------------------------------- | -------- | ------------------------------------ |
-| `claude_code_oauth_token`   | Claude Code OAuth token                                                 | No       |                                      |
-| `anthropic_api_key`         | Anthropic API key (alternative to OAuth token)                          | No       |                                      |
-| `use_bedrock`               | Use Amazon Bedrock with OIDC                                            | No       | `false`                              |
-| `use_vertex`                | Use Google Vertex AI with OIDC                                          | No       | `false`                              |
-| `use_foundry`               | Use Microsoft Foundry with OIDC                                         | No       | `false`                              |
-| `custom_github_token`       | GitHub token (omit to use Claude GitHub App)                            | No       | `""`                                 |
-| `allowed_bots`              | Allowed bot usernames or `*` for all                                    | No       | `*`                                  |
-| `allowed_non_write_users`   | Users without write permission allowed (requires `custom_github_token`) | No       | `""`                                 |
-| `include_comments_by_actor` | Include only comments from specific actors (wildcard support)           | No       | `""`                                 |
-| `exclude_comments_by_actor` | Exclude comments from specific actors (wildcard support)                | No       | `""`                                 |
-| `additional_permissions`    | Additional GitHub App token permissions (e.g. `actions: read`)          | No       | `""`                                 |
-| `settings`                  | Claude Code settings as JSON string or file path                        | No       | `""`                                 |
-| `model`                     | Claude model to use                                                     | No       | `opus[1m]`                           |
-| `allowed_tools`             | Allowed tools (newline-separated, replaces default set)                 | No       | See below                            |
-| `additional_allowed_tools`  | Additional tools to append (newline-separated)                          | No       | `""`                                 |
-| `claude_args`               | Additional CLI arguments                                                | No       | `""`                                 |
-| `include_fix_links`         | Include "Fix this" deep links in review feedback                        | No       | `true`                               |
-| `display_report`            | Show Claude Code Report in Step Summary (`true`/`false`/`auto`)         | No       | `auto` (enabled for private repos)   |
-| `show_full_output`          | Show full JSON output in logs (private repos only)                      | No       | `false`                              |
-| `marketplace_url`           | Git URL of the plugin marketplace                                       | No       | `https://github.com/ncaq/konoka.git` |
-| `plugin_name`               | Plugin identifier within the marketplace                                | No       | `kyosei@konoka`                      |
+All inputs are optional.
+
+#### Authentication
+
+##### `claude_code_oauth_token`
+
+Default: `""`
+
+Claude Code OAuth token.
+
+##### `anthropic_api_key`
+
+Default: `""`
+
+Anthropic API key (alternative to OAuth token).
+
+##### `use_bedrock`
+
+Default: `false`
+
+Use Amazon Bedrock with OIDC authentication.
+
+##### `use_vertex`
+
+Default: `false`
+
+Use Google Vertex AI with OIDC authentication.
+
+##### `use_foundry`
+
+Default: `false`
+
+Use Microsoft Foundry with OIDC authentication.
+
+##### `custom_github_token`
+
+Default: `""`
+
+GitHub token for API access.
+If omitted, claude-code-action uses Claude GitHub App token (claude[bot]).
+Provide explicitly to use a custom token or github.token instead.
+Named custom_github_token to avoid the reserved github_token input name.
+
+#### Access control
+
+##### `allowed_bots`
+
+Default: `*`
+
+Comma-separated list of allowed bot usernames, or `*` to allow all bots.
+Defaults to `*` because bots are not inherently more dangerous than humans.
+
+##### `allowed_non_write_users`
+
+Default: `""`
+
+Comma-separated list of users without write permission who are allowed to trigger Claude,
+or `*` to allow all. Only works when `custom_github_token` is provided.
+Enables bubblewrap sandbox and env scrubbing for safety.
+
+##### `include_comments_by_actor`
+
+Default: `""`
+
+Filter to include only comments from specific actors.
+Supports wildcards (e.g. `*[bot]`). Empty means include all.
+
+##### `exclude_comments_by_actor`
+
+Default: `""`
+
+Filter to exclude comments from specific actors.
+Supports wildcards. Exclusion takes precedence over inclusion.
+
+##### `additional_permissions`
+
+Default: `""`
+
+Additional GitHub permissions for the App token (newline-separated `key: value`).
+Example: `actions: read` enables CI/CD failure analysis.
+Only effective with OIDC token exchange (ignored when `custom_github_token` is set).
+
+##### `settings`
+
+Default: `""`
+
+Claude Code settings as a JSON string or path to a JSON file.
+Merged with existing settings (input takes precedence).
+Can configure hooks, env, MCP settings, etc.
+
+#### Claude Code configuration
+
+##### `model`
+
+Default: `opus[1m]`
+
+Claude model to use.
+
+##### `allowed_tools`
+
+Default: see below.
+
+Allowed tools for Claude Code (newline-separated, replaces default set).
+The defaults broadly allow tools the review agent is likely to need.
+gh api is included because MCP sometimes fails to fetch inline comments.
+
+##### `additional_allowed_tools`
+
+Default: `""`
+
+Additional allowed tools to append to allowed_tools (newline-separated).
+
+##### `claude_args`
+
+Default: `""`
+
+Additional arguments to pass to Claude CLI (appended after --model and --allowed-tools).
+
+#### UI control
+
+##### `include_fix_links`
+
+Default: `true`
+
+Include "Fix this" deep links in PR review feedback.
+
+##### `display_report`
+
+Default: `auto`
+
+Display Claude Code Report in GitHub Step Summary.
+Useful for understanding what Claude did during the review.
+`auto` (default) enables it only for private repositories.
+Can be explicitly set to `true` on public repositories if secrets are properly managed.
+
+##### `show_full_output`
+
+Default: `false`
+
+Show full Claude Code JSON output in Actions logs.
+May contain secrets in tool results; use only for debugging.
+Ignored on public repositories to prevent secret leakage.
+
+#### Marketplace and plugin
+
+##### `marketplace_url`
+
+Default: `https://github.com/ncaq/konoka.git`
+
+Git URL of the plugin marketplace.
+
+##### `plugin_name`
+
+Default: `kyosei@konoka`
+
+Plugin identifier within the marketplace.
 
 #### Default allowed tools
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ jobs:
 | `claude_args`               | Additional CLI arguments                                        | No       | `""`                                 |
 | `include_fix_links`         | Include "Fix this" deep links in review feedback                | No       | `true`                               |
 | `display_report`            | Show Claude Code Report in Step Summary (`true`/`false`/`auto`) | No       | `auto` (enabled for private repos)   |
-| `show_full_output`          | Show full Claude Code JSON output in Actions logs               | No       | `false`                              |
+| `show_full_output`          | Show full JSON output in logs (private repos only)              | No       | `false`                              |
 | `marketplace_url`           | Git URL of the plugin marketplace                               | No       | `https://github.com/ncaq/konoka.git` |
 | `plugin_name`               | Plugin identifier within the marketplace                        | No       | `kyosei@konoka`                      |
 

--- a/README.md
+++ b/README.md
@@ -213,21 +213,29 @@ jobs:
 
 ### Inputs
 
-| Name                       | Description                                             | Required | Default                              |
-| -------------------------- | ------------------------------------------------------- | -------- | ------------------------------------ |
-| `claude_code_oauth_token`  | Claude Code OAuth token                                 | No       |                                      |
-| `anthropic_api_key`        | Anthropic API key (alternative to OAuth token)          | No       |                                      |
-| `use_bedrock`              | Use Amazon Bedrock with OIDC                            | No       | `false`                              |
-| `use_vertex`               | Use Google Vertex AI with OIDC                          | No       | `false`                              |
-| `use_foundry`              | Use Microsoft Foundry with OIDC                         | No       | `false`                              |
-| `custom_github_token`      | GitHub token (omit to use Claude GitHub App)            | No       | `""`                                 |
-| `allowed_bots`             | Allowed bot usernames or `*` for all                    | No       | `*`                                  |
-| `model`                    | Claude model to use                                     | No       | `opus[1m]`                           |
-| `allowed_tools`            | Allowed tools (newline-separated, replaces default set) | No       | See below                            |
-| `additional_allowed_tools` | Additional tools to append (newline-separated)          | No       | `""`                                 |
-| `claude_args`              | Additional CLI arguments                                | No       | `""`                                 |
-| `marketplace_url`          | Git URL of the plugin marketplace                       | No       | `https://github.com/ncaq/konoka.git` |
-| `plugin_name`              | Plugin identifier within the marketplace                | No       | `kyosei@konoka`                      |
+| Name                        | Description                                                     | Required | Default                              |
+| --------------------------- | --------------------------------------------------------------- | -------- | ------------------------------------ |
+| `claude_code_oauth_token`   | Claude Code OAuth token                                         | No       |                                      |
+| `anthropic_api_key`         | Anthropic API key (alternative to OAuth token)                  | No       |                                      |
+| `use_bedrock`               | Use Amazon Bedrock with OIDC                                    | No       | `false`                              |
+| `use_vertex`                | Use Google Vertex AI with OIDC                                  | No       | `false`                              |
+| `use_foundry`               | Use Microsoft Foundry with OIDC                                 | No       | `false`                              |
+| `custom_github_token`       | GitHub token (omit to use Claude GitHub App)                    | No       | `""`                                 |
+| `allowed_bots`              | Allowed bot usernames or `*` for all                            | No       | `*`                                  |
+| `allowed_non_write_users`   | Users without write permission allowed to trigger Claude        | No       | `""`                                 |
+| `include_comments_by_actor` | Include only comments from specific actors (wildcard support)   | No       | `""`                                 |
+| `exclude_comments_by_actor` | Exclude comments from specific actors (wildcard support)        | No       | `""`                                 |
+| `additional_permissions`    | Additional GitHub App token permissions (e.g. `actions: read`)  | No       | `""`                                 |
+| `settings`                  | Claude Code settings as JSON string or file path                | No       | `""`                                 |
+| `model`                     | Claude model to use                                             | No       | `opus[1m]`                           |
+| `allowed_tools`             | Allowed tools (newline-separated, replaces default set)         | No       | See below                            |
+| `additional_allowed_tools`  | Additional tools to append (newline-separated)                  | No       | `""`                                 |
+| `claude_args`               | Additional CLI arguments                                        | No       | `""`                                 |
+| `include_fix_links`         | Include "Fix this" deep links in review feedback                | No       | `true`                               |
+| `display_report`            | Show Claude Code Report in Step Summary (`true`/`false`/`auto`) | No       | `auto` (enabled for private repos)   |
+| `show_full_output`          | Show full Claude Code JSON output in Actions logs               | No       | `false`                              |
+| `marketplace_url`           | Git URL of the plugin marketplace                               | No       | `https://github.com/ncaq/konoka.git` |
+| `plugin_name`               | Plugin identifier within the marketplace                        | No       | `kyosei@konoka`                      |
 
 #### Default allowed tools
 

--- a/README.md
+++ b/README.md
@@ -213,29 +213,29 @@ jobs:
 
 ### Inputs
 
-| Name                        | Description                                                     | Required | Default                              |
-| --------------------------- | --------------------------------------------------------------- | -------- | ------------------------------------ |
-| `claude_code_oauth_token`   | Claude Code OAuth token                                         | No       |                                      |
-| `anthropic_api_key`         | Anthropic API key (alternative to OAuth token)                  | No       |                                      |
-| `use_bedrock`               | Use Amazon Bedrock with OIDC                                    | No       | `false`                              |
-| `use_vertex`                | Use Google Vertex AI with OIDC                                  | No       | `false`                              |
-| `use_foundry`               | Use Microsoft Foundry with OIDC                                 | No       | `false`                              |
-| `custom_github_token`       | GitHub token (omit to use Claude GitHub App)                    | No       | `""`                                 |
-| `allowed_bots`              | Allowed bot usernames or `*` for all                            | No       | `*`                                  |
-| `allowed_non_write_users`   | Users without write permission allowed to trigger Claude        | No       | `""`                                 |
-| `include_comments_by_actor` | Include only comments from specific actors (wildcard support)   | No       | `""`                                 |
-| `exclude_comments_by_actor` | Exclude comments from specific actors (wildcard support)        | No       | `""`                                 |
-| `additional_permissions`    | Additional GitHub App token permissions (e.g. `actions: read`)  | No       | `""`                                 |
-| `settings`                  | Claude Code settings as JSON string or file path                | No       | `""`                                 |
-| `model`                     | Claude model to use                                             | No       | `opus[1m]`                           |
-| `allowed_tools`             | Allowed tools (newline-separated, replaces default set)         | No       | See below                            |
-| `additional_allowed_tools`  | Additional tools to append (newline-separated)                  | No       | `""`                                 |
-| `claude_args`               | Additional CLI arguments                                        | No       | `""`                                 |
-| `include_fix_links`         | Include "Fix this" deep links in review feedback                | No       | `true`                               |
-| `display_report`            | Show Claude Code Report in Step Summary (`true`/`false`/`auto`) | No       | `auto` (enabled for private repos)   |
-| `show_full_output`          | Show full JSON output in logs (private repos only)              | No       | `false`                              |
-| `marketplace_url`           | Git URL of the plugin marketplace                               | No       | `https://github.com/ncaq/konoka.git` |
-| `plugin_name`               | Plugin identifier within the marketplace                        | No       | `kyosei@konoka`                      |
+| Name                        | Description                                                             | Required | Default                              |
+| --------------------------- | ----------------------------------------------------------------------- | -------- | ------------------------------------ |
+| `claude_code_oauth_token`   | Claude Code OAuth token                                                 | No       |                                      |
+| `anthropic_api_key`         | Anthropic API key (alternative to OAuth token)                          | No       |                                      |
+| `use_bedrock`               | Use Amazon Bedrock with OIDC                                            | No       | `false`                              |
+| `use_vertex`                | Use Google Vertex AI with OIDC                                          | No       | `false`                              |
+| `use_foundry`               | Use Microsoft Foundry with OIDC                                         | No       | `false`                              |
+| `custom_github_token`       | GitHub token (omit to use Claude GitHub App)                            | No       | `""`                                 |
+| `allowed_bots`              | Allowed bot usernames or `*` for all                                    | No       | `*`                                  |
+| `allowed_non_write_users`   | Users without write permission allowed (requires `custom_github_token`) | No       | `""`                                 |
+| `include_comments_by_actor` | Include only comments from specific actors (wildcard support)           | No       | `""`                                 |
+| `exclude_comments_by_actor` | Exclude comments from specific actors (wildcard support)                | No       | `""`                                 |
+| `additional_permissions`    | Additional GitHub App token permissions (e.g. `actions: read`)          | No       | `""`                                 |
+| `settings`                  | Claude Code settings as JSON string or file path                        | No       | `""`                                 |
+| `model`                     | Claude model to use                                                     | No       | `opus[1m]`                           |
+| `allowed_tools`             | Allowed tools (newline-separated, replaces default set)                 | No       | See below                            |
+| `additional_allowed_tools`  | Additional tools to append (newline-separated)                          | No       | `""`                                 |
+| `claude_args`               | Additional CLI arguments                                                | No       | `""`                                 |
+| `include_fix_links`         | Include "Fix this" deep links in review feedback                        | No       | `true`                               |
+| `display_report`            | Show Claude Code Report in Step Summary (`true`/`false`/`auto`)         | No       | `auto` (enabled for private repos)   |
+| `show_full_output`          | Show full JSON output in logs (private repos only)                      | No       | `false`                              |
+| `marketplace_url`           | Git URL of the plugin marketplace                                       | No       | `https://github.com/ncaq/konoka.git` |
+| `plugin_name`               | Plugin identifier within the marketplace                                | No       | `kyosei@konoka`                      |
 
 #### Default allowed tools
 

--- a/action.yml
+++ b/action.yml
@@ -124,6 +124,7 @@ inputs:
       Display Claude Code Report in GitHub Step Summary.
       Useful for understanding what Claude did during the review.
       "auto" (default) enables it only for private repositories.
+      Can be explicitly set to "true" on public repositories if secrets are properly managed.
     required: false
     default: "auto"
   show_full_output:

--- a/action.yml
+++ b/action.yml
@@ -266,7 +266,7 @@ runs:
         exclude_comments_by_actor: ${{ inputs.exclude_comments_by_actor }}
         additional_permissions: ${{ inputs.additional_permissions }}
         settings: ${{ inputs.settings }}
-        include_fix_links: ${{ inputs.include_fix_links }}
+        include_fix_links: ${{ inputs.include_fix_links == 'true' && 'true' || 'false' }}
         display_report: ${{ (inputs.display_report == 'auto' && github.event.repository.private || inputs.display_report == 'true') && 'true' || 'false' }}
         show_full_output: ${{ (inputs.show_full_output == 'true' && github.event.repository.private) && 'true' || 'false' }}
         claude_args: >-

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,7 @@ inputs:
     description: >-
       Show full Claude Code JSON output in Actions logs.
       May contain secrets in tool results; use only for debugging.
+      Ignored on public repositories to prevent secret leakage.
     required: false
     default: "false"
 
@@ -266,7 +267,7 @@ runs:
         settings: ${{ inputs.settings }}
         include_fix_links: ${{ inputs.include_fix_links }}
         display_report: ${{ (inputs.display_report == 'auto' && github.event.repository.private || inputs.display_report == 'true') && 'true' || 'false' }}
-        show_full_output: ${{ inputs.show_full_output }}
+        show_full_output: ${{ (inputs.show_full_output == 'true' && github.event.repository.private) && 'true' || 'false' }}
         claude_args: >-
           --model "${{ inputs.model }}"
           --allowed-tools "${{ steps.build-allowed-tools.outputs.joined }}"

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,39 @@ inputs:
       Defaults to '*' because bots are not inherently more dangerous than humans.
     required: false
     default: "*"
+  allowed_non_write_users:
+    description: >-
+      Comma-separated list of users without write permission who are allowed to trigger Claude,
+      or '*' to allow all. Only works when custom_github_token is provided.
+      Enables bubblewrap sandbox and env scrubbing for safety.
+    required: false
+    default: ""
+  include_comments_by_actor:
+    description: >-
+      Filter to include only comments from specific actors.
+      Supports wildcards (e.g. '*[bot]'). Empty means include all.
+    required: false
+    default: ""
+  exclude_comments_by_actor:
+    description: >-
+      Filter to exclude comments from specific actors.
+      Supports wildcards. Exclusion takes precedence over inclusion.
+    required: false
+    default: ""
+  additional_permissions:
+    description: >-
+      Additional GitHub permissions for the App token (newline-separated 'key: value').
+      Example: 'actions: read' enables CI/CD failure analysis.
+      Only effective with OIDC token exchange (ignored when custom_github_token is set).
+    required: false
+    default: ""
+  settings:
+    description: >-
+      Claude Code settings as a JSON string or path to a JSON file.
+      Merged with existing settings (input takes precedence).
+      Can configure hooks, env, MCP settings, etc.
+    required: false
+    default: ""
 
   # Claude Code configuration
   model:
@@ -80,6 +113,25 @@ inputs:
     description: Additional arguments to pass to Claude CLI (appended after --model and --allowed-tools)
     required: false
     default: ""
+
+  # UI control
+  include_fix_links:
+    description: Include 'Fix this' deep links in PR review feedback
+    required: false
+    default: "true"
+  display_report:
+    description: >-
+      Display Claude Code Report in GitHub Step Summary.
+      Useful for understanding what Claude did during the review.
+      "auto" (default) enables it only for private repositories.
+    required: false
+    default: "auto"
+  show_full_output:
+    description: >-
+      Show full Claude Code JSON output in Actions logs.
+      May contain secrets in tool results; use only for debugging.
+    required: false
+    default: "false"
 
   # Marketplace and plugin
   marketplace_url:
@@ -207,6 +259,14 @@ runs:
         use_foundry: ${{ inputs.use_foundry }}
         github_token: ${{ inputs.custom_github_token }} # Pass as-is (empty means claude-code-action uses Claude GitHub App token).
         allowed_bots: ${{ inputs.allowed_bots }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        include_comments_by_actor: ${{ inputs.include_comments_by_actor }}
+        exclude_comments_by_actor: ${{ inputs.exclude_comments_by_actor }}
+        additional_permissions: ${{ inputs.additional_permissions }}
+        settings: ${{ inputs.settings }}
+        include_fix_links: ${{ inputs.include_fix_links }}
+        display_report: ${{ inputs.display_report != 'auto' && inputs.display_report || (github.event.repository.private && 'true' || 'false') }}
+        show_full_output: ${{ inputs.show_full_output }}
         claude_args: >-
           --model "${{ inputs.model }}"
           --allowed-tools "${{ steps.build-allowed-tools.outputs.joined }}"

--- a/action.yml
+++ b/action.yml
@@ -265,7 +265,7 @@ runs:
         additional_permissions: ${{ inputs.additional_permissions }}
         settings: ${{ inputs.settings }}
         include_fix_links: ${{ inputs.include_fix_links }}
-        display_report: ${{ inputs.display_report != 'auto' && inputs.display_report || (github.event.repository.private && 'true' || 'false') }}
+        display_report: ${{ (inputs.display_report == 'auto' && github.event.repository.private || inputs.display_report == 'true') && 'true' || 'false' }}
         show_full_output: ${{ inputs.show_full_output }}
         claude_args: >-
           --model "${{ inputs.model }}"


### PR DESCRIPTION
claude-code-actionが提供するレビュー関連のinputsのうち、
kyosei-actionでまだ設定できなかった8つのオプションを追加しました。
action.yml、review.yml(Reusable Workflow)、READMEの3箇所を更新しています。

追加したオプション:
- `allowed_non_write_users`: write権限のないユーザーの許可
- `include_comments_by_actor`: 特定actorのコメントのみ含める
- `exclude_comments_by_actor`: 特定actorのコメントを除外
- `additional_permissions`: 追加GitHub権限
- `settings`: Claude Code設定(JSON/ファイルパス)
- `include_fix_links`: 「Fix this」ディープリンク(デフォルト: true)
- `display_report`: Step Summaryレポート(デフォルト: auto、privateリポジトリのみ有効)
- `show_full_output`: デバッグ用フル出力

`use_sticky_comment`と`track_progress`はkyoseiのコンセプトやレビュー用途に合わないため除外しています。

close #23
