### PR TITLE
build(deps): konokaをv5.0.0に更新しresearchプラグインを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,13 +4,14 @@
       "source": {
         "source": "github",
         "repo": "ncaq/konoka",
-        "ref": "v4.0.0"
+        "ref": "v5.0.0"
       }
     }
   },
   "enabledPlugins": {
     "kyosei@konoka": true,
-    "nix-tasuke@konoka": true
+    "nix-tasuke@konoka": true,
+    "research@konoka": true
   },
   "enableAllProjectMcpServers": true,
   "permissions": {

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -156,7 +156,9 @@ on:
         description: Plugin identifier within the marketplace
         type: string
         required: false
-        default: "kyosei@konoka"
+        default: |-
+          kyosei@konoka
+          research@konoka
 
       # Workflow configuration
       runs-on:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -153,7 +153,7 @@ on:
         required: false
         default: "https://github.com/ncaq/konoka.git"
       plugin_name:
-        description: Plugin identifier within the marketplace
+        description: Plugin identifier within the marketplace (newline-separated for multiple)
         type: string
         required: false
         default: |-

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Git URL of the plugin marketplace.
 
 ##### `plugin_name`
 
-Default: `kyosei@konoka`
+Default: `kyosei@konoka` and `research@konoka` (newline-separated)
 
 Plugin identifier within the marketplace.
 

--- a/action.yml
+++ b/action.yml
@@ -143,7 +143,9 @@ inputs:
   plugin_name:
     description: Plugin identifier within the marketplace
     required: false
-    default: "kyosei@konoka"
+    default: |-
+      kyosei@konoka
+      research@konoka
 
 outputs:
   execution_file:

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ inputs:
     required: false
     default: "https://github.com/ncaq/konoka.git"
   plugin_name:
-    description: Plugin identifier within the marketplace
+    description: Plugin identifier within the marketplace (newline-separated for multiple)
     required: false
     default: |-
       kyosei@konoka


### PR DESCRIPTION
konokaのバージョンをv4.0.0からv5.0.0に更新しました。
kyoseiがresearchプラグインを利用することを前提としたため、
`plugin_name`のデフォルトに`research@konoka`を追加しました。
