### PR TITLE
fix: claude-user-request.txtを生成してスラッシュコマンドの埋め込みコマンド展開を有効化

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -251,6 +251,14 @@ runs:
         echo "joined=$joined" >> "$GITHUB_OUTPUT"
         echo "::endgroup::"
 
+    - name: Write user request for slash command support
+      shell: bash
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      run: |
+        mkdir -p "${RUNNER_TEMP}/claude-prompts"
+        echo "/kyosei ${PR_URL}" > "${RUNNER_TEMP}/claude-prompts/claude-user-request.txt"
+
     - name: Run Kyosei
       id: claude-review
       continue-on-error: true
@@ -277,7 +285,7 @@ runs:
           ${{ inputs.claude_args }}
         plugin_marketplaces: ${{ inputs.marketplace_url }}
         plugins: ${{ inputs.plugin_name }}
-        prompt: "/kyosei ${{ github.event.pull_request.html_url }}"
+        prompt: "Follow the user request."
 
     # If claude-code-action fails, emit a warning instead of failing the workflow.
     # Common causes: insufficient token permissions (e.g. workflow file changes


### PR DESCRIPTION
claude-code-actionのagentモードではpromptが単純な文字列として渡され、
スキルの埋め込みコマンド(!コマンド)が正しく処理されない問題があった。
claude-code-actionはclaude-user-request.txtが存在する場合のみ
マルチブロックメッセージを生成してスラッシュコマンドを処理するため、
このファイルを事前に作成するステップを追加する。
