### PR TITLE
fix: デフォルトのallowed_toolsにBash(node:*)を追加

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -104,6 +104,7 @@ on:
           Bash(gh issue:*)
           Bash(gh pr:*)
           Bash(gh search:*)
+          Bash(node:*)
           Glob
           Grep
           Read

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ allowed_tools: |
   Bash(gh issue:*)
   Bash(gh pr:*)
   Bash(gh search:*)
+  Bash(node:*)
   Glob
   Grep
   Read

--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,7 @@ inputs:
       Bash(gh issue:*)
       Bash(gh pr:*)
       Bash(gh search:*)
+      Bash(node:*)
       Glob
       Grep
       Read


### PR DESCRIPTION
スキル側でTypeScriptコードを実行するためにnodeコマンドを許可する。
