### PR TITLE
ci(renovate): セルフ参照をRenovateの更新対象から除外

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ncaq/renovate-config"]
+  "extends": ["github>ncaq/renovate-config"],
+  "packageRules": [
+    {
+      "description": "self-reference; hash is unknown until after merge, and immutable releases make tag pinning safe",
+      "matchPackageNames": ["ncaq/kyosei-action"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
このプロジェクトは自身のactionをワークフロー内で使用しているため、
ハッシュピン留めはマージ後までハッシュが確定しない都合上不可能です。
immutableリリースを使用しておりタグピン留めで十分安全なため、
`ncaq/kyosei-action`をRenovateの管理対象外に設定しました。
