### PR TITLE
fix: `runs-on`入力でプレーンな文字列を受け付けるように対応

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -164,12 +164,13 @@ on:
       # Workflow configuration
       runs-on:
         description: >-
-          Runner label(s) for the job. Must be a valid JSON value because it is parsed with fromJSON().
-          A single label ("ubuntu-24.04") or an array (["self-hosted", "linux"]) are both accepted.
-          Note: bare strings without quotes (e.g. ubuntu-24.04) will fail.
+          Runner label(s) for the job.
+          A single label can be written as a plain string (e.g. ubuntu-24.04)
+          or a JSON string (e.g. "ubuntu-24.04").
+          Multiple labels require a JSON array (e.g. ["self-hosted", "linux"]).
         type: string
         required: false
-        default: '"ubuntu-24.04"'
+        default: ubuntu-24.04
       timeout-minutes:
         description: Job timeout in minutes. Set as a safeguard against hangs.
         type: number
@@ -209,7 +210,7 @@ concurrency:
 jobs:
   kyosei:
     name: review
-    runs-on: ${{ fromJSON(inputs['runs-on']) }}
+    runs-on: ${{ fromJSON(startsWith(inputs['runs-on'], '"') && inputs['runs-on'] || startsWith(inputs['runs-on'], '[') && inputs['runs-on'] || format('"{0}"', inputs['runs-on'])) }}
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions
     # (e.g. pull-requests: write) must be granted by the caller.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -168,6 +168,7 @@ on:
           A single label can be written as a plain string (e.g. ubuntu-24.04)
           or a JSON string (e.g. "ubuntu-24.04").
           Multiple labels require a JSON array (e.g. ["self-hosted", "linux"]).
+          An object with group/labels keys (e.g. {"group":"my-group","labels":["x64"]}) is also accepted.
         type: string
         required: false
         default: ubuntu-24.04
@@ -210,7 +211,12 @@ concurrency:
 jobs:
   kyosei:
     name: review
-    runs-on: ${{ fromJSON(startsWith(inputs['runs-on'], '"') && inputs['runs-on'] || startsWith(inputs['runs-on'], '[') && inputs['runs-on'] || format('"{0}"', inputs['runs-on'])) }}
+    # Normalize runs-on input for fromJSON():
+    #   - JSON-quoted string (starts with "): pass through
+    #   - JSON array (starts with [): pass through
+    #   - JSON object (starts with {): pass through
+    #   - Plain string: wrap in JSON quotes via format()
+    runs-on: ${{ fromJSON(startsWith(inputs['runs-on'], '"') && inputs['runs-on'] || startsWith(inputs['runs-on'], '[') && inputs['runs-on'] || startsWith(inputs['runs-on'], '{') && inputs['runs-on'] || format('"{0}"', inputs['runs-on'])) }}
     # Claude GitHub App manages its own token, so only minimal permissions are needed.
     # If the caller passes custom_github_token explicitly, additional permissions
     # (e.g. pull-requests: write) must be granted by the caller.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The Reusable Workflow additionally accepts the following inputs:
 
 | Name                   | Description                                                                | Default        |
 | ---------------------- | -------------------------------------------------------------------------- | -------------- |
-| `runs-on`              | Runner label(s) (plain string or JSON)                                     | `ubuntu-24.04` |
+| `runs-on`              | Runner label(s) (plain string, JSON string/array/object)                   | `ubuntu-24.04` |
 | `timeout-minutes`      | Job timeout in minutes                                                     | `30`           |
 | `fetch-depth`          | Number of commits to fetch                                                 | `50`           |
 | `self_hosted_packages` | Packages to install via apt-get on self-hosted runners (newline-separated) | See below      |
@@ -161,7 +161,7 @@ On GitHub-hosted runners this step is always skipped regardless of the input val
 
 ### `runs-on` format
 
-`runs-on` accepts a plain string, a JSON-quoted string, or a JSON array:
+`runs-on` accepts a plain string, a JSON-quoted string, a JSON array, or a JSON object:
 
 ```yaml
 # Single label (plain string)
@@ -175,6 +175,10 @@ with:
 # Multiple labels (JSON array)
 with:
   runs-on: '["self-hosted", "linux"]'
+
+# Runner group with labels (JSON object)
+with:
+  runs-on: '{"group":"my-group","labels":["x64"]}'
 ```
 
 See the Composite Action section below for the full input list.

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ jobs:
 Most Composite Action inputs can be passed via `with:`.
 The Reusable Workflow additionally accepts the following inputs:
 
-| Name                   | Description                                                                | Default          |
-| ---------------------- | -------------------------------------------------------------------------- | ---------------- |
-| `runs-on`              | Runner label(s) as JSON                                                    | `"ubuntu-24.04"` |
-| `timeout-minutes`      | Job timeout in minutes                                                     | `30`             |
-| `fetch-depth`          | Number of commits to fetch                                                 | `50`             |
-| `self_hosted_packages` | Packages to install via apt-get on self-hosted runners (newline-separated) | See below        |
+| Name                   | Description                                                                | Default        |
+| ---------------------- | -------------------------------------------------------------------------- | -------------- |
+| `runs-on`              | Runner label(s) (plain string or JSON)                                     | `ubuntu-24.04` |
+| `timeout-minutes`      | Job timeout in minutes                                                     | `30`           |
+| `fetch-depth`          | Number of commits to fetch                                                 | `50`           |
+| `self_hosted_packages` | Packages to install via apt-get on self-hosted runners (newline-separated) | See below      |
 
 ### Self-hosted runners
 
@@ -161,15 +161,18 @@ On GitHub-hosted runners this step is always skipped regardless of the input val
 
 ### `runs-on` format
 
-`runs-on` is parsed with `fromJSON()`, so the value must be valid JSON.
-YAML double quotes are stripped by the YAML parser, so you need to nest JSON quotes inside YAML single quotes:
+`runs-on` accepts a plain string, a JSON-quoted string, or a JSON array:
 
 ```yaml
-# Single label
+# Single label (plain string)
+with:
+  runs-on: ubuntu-24.04
+
+# Single label (JSON string — also works)
 with:
   runs-on: '"ubuntu-24.04"'
 
-# Multiple labels
+# Multiple labels (JSON array)
 with:
   runs-on: '["self-hosted", "linux"]'
 ```


### PR DESCRIPTION
従来は`fromJSON()`で直接パースしていたため、
`runs-on`の値をJSONクォートで囲む必要がありました。
入力値が`"`や`[`で始まらない場合は自動的にJSON文字列としてラップすることで、
`ubuntu-24.04`のようなプレーンな文字列もそのまま渡せるようになりました。
fromJSONが失敗すると全体失敗するので、
プレーンな文字列をそのまま渡すのではなくJSONに簡易的に変換しています。
jqなどで検査するのは失敗したときに単にワークフローがエラーになるだけなのに対して、
あまりにも大げさすぎるため、
今回はシンプルな方法を使いました。

close #38
