### PR TITLE
ci: 内部のreviewで`display_report`を`true`にする

### DIFF
--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -17,5 +17,10 @@ jobs:
       contents: read # Read repository contents for checkout
       id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
     uses: ./.github/workflows/review.yml
+    with:
+      # For debugging.
+      # When it repository is safe,
+      # Because secrets isn't critical secrets.
+      display_report: true
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -21,6 +21,6 @@ jobs:
       # For debugging.
       # When it repository is safe,
       # Because secrets isn't critical secrets.
-      display_report: true
+      display_report: "true"
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -21,6 +21,6 @@ jobs:
       # For debugging.
       # When it repository is safe,
       # Because secrets isn't critical secrets.
-      display_report: "true"
+      display_report: ${{ 'true' }} # zizmor: ignore[obfuscation] -- actionlint false positive workaround: string type input requires expression syntax to avoid bool coercion
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
これ自体のデバッグをできるようにするため。
どうせこのリポジトリにはCachixの個別トークンとか、
Claude Codeの利用可能トークンぐらいしかないので、
仮に漏れても大したことはないので安全。
そもそも`display_report`でシークレットが軽々しく漏れることはないはずですし。
