### PR TITLE
docs: READMEのバージョン表記をv1.4.0に更新

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,3 +50,12 @@ CLAUDE.md -> .github/copilot-instructions.md
 ```
 
 これにより各種LLM向けのドキュメントを一元管理しています。
+
+# バージョン更新時の注意
+
+`VERSION`ファイルを更新する際は、以下のファイル内のバージョン表記も全て一致させてください。
+`VERSION`を更新するとCIが自動でリリースタグを作成するため、事前に揃えておく必要があります。
+
+- `VERSION`: バージョンの定義元(`x.y.z`形式、`v`プレフィックスなし)
+- `README.md`: 使用例やコマンド例に含まれるバージョンタグ(`@vx.y.z`形式)
+- `.github/workflows/review.yml`: セルフ参照の`uses: ncaq/kyosei-action@vx.y.z`

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -241,7 +241,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: ${{ inputs['fetch-depth'] }}
-      - uses: ncaq/kyosei-action@v1.3.0 # zizmor: ignore[unpinned-uses] self-reference; immutable releases make tag pinning safe
+      - uses: ncaq/kyosei-action@v1.4.0 # zizmor: ignore[unpinned-uses] self-reference; immutable releases make tag pinning safe
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Paste the token when prompted.
 
 This project follows immutable releases:
 once a version tag is published, it is never moved or overwritten.
-Version tags such as `@v1.4.0` are safe to use as-is.
+Version tags such as `kyosei-action@v1.4.0` are safe to use as-is.
 
 If your policy requires pinning to a commit hash rather than a tag,
 you need the commit SHA, not the tag object SHA.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Paste the token when prompted.
 
 This project follows immutable releases:
 once a version tag is published, it is never moved or overwritten.
-Version tags such as `@v1.3.0` are safe to use as-is.
+Version tags such as `@v1.4.0` are safe to use as-is.
 
 If your policy requires pinning to a commit hash rather than a tag,
 you need the commit SHA, not the tag object SHA.
@@ -90,10 +90,10 @@ GitHub Actions requires the commit SHA.
 Use `^{commit}` to dereference the tag:
 
 ```console
-git rev-parse v1.3.0^{commit}
+git rev-parse v1.4.0^{commit}
 ```
 
-Do not use `git rev-parse v1.3.0` without `^{commit}`.
+Do not use `git rev-parse v1.4.0` without `^{commit}`.
 For annotated tags it returns the tag object SHA, which GitHub Actions cannot resolve.
 
 ## Reusable Workflow
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: read # Read repository contents for checkout
       id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
-    uses: ncaq/kyosei-action/.github/workflows/review.yml@v1.3.0
+    uses: ncaq/kyosei-action/.github/workflows/review.yml@v1.4.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -213,7 +213,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 50
-      - uses: ncaq/kyosei-action@v1.3.0
+      - uses: ncaq/kyosei-action@v1.4.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
@@ -402,7 +402,7 @@ allowed_tools: |
 To add tools without replacing the defaults, use `additional_allowed_tools`:
 
 ```yaml
-- uses: ncaq/kyosei-action@v1.3.0
+- uses: ncaq/kyosei-action@v1.4.0
   with:
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     additional_allowed_tools: |

--- a/flake.nix
+++ b/flake.nix
@@ -84,9 +84,9 @@
                   '';
                 };
                 includes = [
-                  "VERSION"
-                  "README.md"
                   ".github/workflows/review.yml"
+                  "README.md"
+                  "VERSION"
                 ];
               };
               zizmor.options = [ "--pedantic" ];

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,8 @@
                     coreutils
                     gnugrep
                   ];
+                  # treefmtの引数は無視しますが数が少ないのでこちらの方がシンプル。
+                  # 一応必要なキャッシュは働くので単にcheckにするよりは効率的。
                   text = ''
                     VERSION=$(tr -d '[:space:]' < ${./VERSION})
                     TAG="v$VERSION"
@@ -86,7 +88,7 @@
                 includes = [
                   ".github/workflows/review.yml"
                   "README.md"
-                  "VERSION"
+                  "VERSION" # 編集はしないけどトリガーのために含める。
                 ];
               };
               zizmor.options = [ "--pedantic" ];

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,9 @@
                         errors=$((errors + 1))
                       fi
                     done
-                    exit "$errors"
+                    if [ "$errors" -gt 0 ]; then
+                      exit 1
+                    fi
                   '';
                 };
                 includes = [

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,35 @@
                 command = pkgs.editorconfig-checker;
                 includes = [ "*" ];
               };
+              self-version = {
+                command = pkgs.writeShellApplication {
+                  name = "self-version";
+                  runtimeInputs = with pkgs; [
+                    coreutils
+                    gnugrep
+                  ];
+                  text = ''
+                    VERSION=$(tr -d '[:space:]' < ${./VERSION})
+                    TAG="v$VERSION"
+                    PATTERN='(?:kyosei-action(?:@|/[^@]*@)|rev-parse\s+)v\d+\.\d+\.\d+'
+                    errors=0
+                    for file in ${./README.md} ${./.github/workflows/review.yml}; do
+                      stale=$(grep -nP "$PATTERN" "$file" | grep -vF "$TAG" || true)
+                      if [ -n "$stale" ]; then
+                        echo "self-version: $file contains outdated version (expected $TAG):" >&2
+                        echo "$stale" >&2
+                        errors=$((errors + 1))
+                      fi
+                    done
+                    exit "$errors"
+                  '';
+                };
+                includes = [
+                  "VERSION"
+                  "README.md"
+                  ".github/workflows/review.yml"
+                ];
+              };
               zizmor.options = [ "--pedantic" ];
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
                     PATTERN='(?:kyosei-action(?:@|/[^@]*@)|rev-parse\s+)v\d+\.\d+\.\d+'
                     errors=0
                     for file in ${./README.md} ${./.github/workflows/review.yml}; do
-                      stale=$(grep -nP "$PATTERN" "$file" | grep -vF "$TAG" || true)
+                      stale=$(grep -nP "$PATTERN" "$file" | grep -vP "v$VERSION(?!\\.|-)" || true)
                       if [ -n "$stale" ]; then
                         echo "self-version: $file contains outdated version (expected $TAG):" >&2
                         echo "$stale" >&2


### PR DESCRIPTION
v1.4.0のタグを作成した際にREADME内の使用例やコマンド例が
v1.3.0のままになっていたため、全箇所をv1.4.0に更新しました。
