### PR TITLE
ci: 内部CIのセルフ参照をファイルパスベースに変更

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,4 +58,3 @@ CLAUDE.md -> .github/copilot-instructions.md
 
 - `VERSION`: バージョンの定義元(`x.y.z`形式、`v`プレフィックスなし)
 - `README.md`: 使用例やコマンド例に含まれるバージョンタグ(`@vx.y.z`形式)
-- `.github/workflows/review.yml`: セルフ参照の`uses: ncaq/kyosei-action@vx.y.z`

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -291,7 +291,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: ${{ inputs['fetch-depth'] }}
-      - uses: ncaq/kyosei-action@v1.5.0 # zizmor: ignore[unpinned-uses] self-reference; immutable releases make tag pinning safe
+      - uses: ./ # Local composite action (file-path based self-reference)
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}

--- a/flake.nix
+++ b/flake.nix
@@ -73,22 +73,16 @@
                     VERSION=$(tr -d '[:space:]' < ${./VERSION})
                     TAG="v$VERSION"
                     PATTERN='(?:kyosei-action(?:@|/[^@]*@)|rev-parse\s+)v\d+\.\d+\.\d+'
-                    errors=0
-                    for file in ${./README.md} ${./.github/workflows/review.yml}; do
-                      stale=$(grep -nP "$PATTERN" "$file" | grep -vP "v$VERSION(?!\\.|-)" || true)
-                      if [ -n "$stale" ]; then
-                        echo "self-version: $file contains outdated version (expected $TAG):" >&2
-                        echo "$stale" >&2
-                        errors=$((errors + 1))
-                      fi
-                    done
-                    if [ "$errors" -gt 0 ]; then
+                    file=${./README.md}
+                    stale=$(grep -nP "$PATTERN" "$file" | grep -vP "v$VERSION(?!\\.|-)" || true)
+                    if [ -n "$stale" ]; then
+                      echo "self-version: $file contains outdated version (expected $TAG):" >&2
+                      echo "$stale" >&2
                       exit 1
                     fi
                   '';
                 };
                 includes = [
-                  ".github/workflows/review.yml"
                   "README.md"
                   "VERSION" # 編集はしないけどトリガーのために含める。
                 ];


### PR DESCRIPTION
reusable workflow内の`uses: ncaq/kyosei-action@v1.5.0`を`uses: ./`に変更しました。
タグベースのセルフ参照ではClaude Code Reviewの権限が切れる頻度が高かったためです。
ファイルパスベースになったことでreview.ymlはバージョン更新の対象外になるため、
flake.nixのself-versionチェッカーとCLAUDE.mdのバージョン更新手順からもreview.ymlを除外しました。

close #64
