### PR TITLE
docs: commit hashの取得方法をclone不要な`git ls-remote`に変更

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,5 +57,5 @@ CLAUDE.md -> .github/copilot-instructions.md
 `VERSION`を更新するとCIが自動でリリースタグを作成するため、事前に揃えておく必要があります。
 
 - `VERSION`: バージョンの定義元(`x.y.z`形式、`v`プレフィックスなし)
-- `README.md`: 使用例やコマンド例に含まれるバージョンタグ(`@vx.y.z`形式)
+- `README.md`: コピペ可能な使用例に含まれるバージョンタグ(`@vx.y.z`形式)
 - `.github/workflows/review.yml`: セルフ参照の`uses: ncaq/kyosei-action@vx.y.z`

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ you need the commit SHA, not the tag object SHA.
 Annotated tags have their own object SHA which differs from the commit SHA.
 GitHub Actions requires the commit SHA.
 
-Use `^{commit}` to dereference the tag:
+Use `git ls-remote` with `^{}` to fetch the dereferenced commit SHA without cloning the repository:
 
 ```console
-git rev-parse v2.0.1^{commit}
+git ls-remote https://github.com/ncaq/kyosei-action.git 'refs/tags/v2.0.1^{}'
 ```
 
-Do not use `git rev-parse v2.0.1` without `^{commit}`.
+Do not query `refs/tags/v2.0.1` without `^{}`.
 For annotated tags it returns the tag object SHA, which GitHub Actions cannot resolve.
 
 ## Reusable Workflow


### PR DESCRIPTION
`Pinning to a commit hash`セクションでは`git rev-parse vX.Y.Z^{commit}`を案内していましたが、
これはローカルにcloneしてfetchしてあるリポジトリでないとtagを解決できません。
利用者にとってはcommit hashを知るためだけにcloneするのは過剰な手順なので、
`git ls-remote`の`refs/tags/<tag>^{}`構文でリモート参照だけからdereferenceした
commit SHAを取得する方法に書き換えました。

合わせて`copilot-instructions.md`の`README.md`の説明を、
バージョン同期が必要な箇所が「コピペ可能な使用例」であることが伝わる文言に微修正しました。
