### PR TITLE
feat: トップレベルセッションの`effort`を下げる`input`を追加

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -94,8 +94,10 @@ on:
         description: >-
           Reasoning effort level for the top-level orchestrator session
           (low, medium, high, xhigh, max).
-          Reviewer subagents have their own `effort: high` in agent frontmatter
-          and are not affected by this value.
+          The kyosei skill itself only dispatches reviewer subagents and posts JSON,
+          so a lower level reduces cost and latency without affecting review quality.
+          Reviewer subagents have their own `effort: high` in agent frontmatter,
+          which overrides this session-level value per Claude Code's agent fields spec.
           Set to an empty string to omit the flag and use the model default.
         type: string
         required: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -90,6 +90,16 @@ on:
         type: string
         required: false
         default: "opus[1m]"
+      effort:
+        description: >-
+          Reasoning effort level for the top-level orchestrator session
+          (low, medium, high, xhigh, max).
+          Reviewer subagents have their own `effort: high` in agent frontmatter
+          and are not affected by this value.
+          Set to an empty string to omit the flag and use the model default.
+        type: string
+        required: false
+        default: "medium"
       allowed_tools:
         description: >-
           Allowed tools for Claude Code (newline-separated, replaces default set).
@@ -334,6 +344,7 @@ jobs:
           additional_permissions: ${{ inputs.additional_permissions }}
           settings: ${{ inputs.settings }}
           model: ${{ inputs.model }}
+          effort: ${{ inputs.effort }}
           allowed_tools: ${{ inputs.allowed_tools }}
           additional_allowed_tools: ${{ inputs.additional_allowed_tools }}
           claude_args: ${{ inputs.claude_args }}

--- a/README.md
+++ b/README.md
@@ -294,6 +294,24 @@ Default: `opus[1m]`
 
 Claude model to use.
 
+##### `effort`
+
+Default: `medium`
+
+Reasoning effort level for the top-level orchestrator session.
+Valid values: `low`, `medium`, `high`, `xhigh`, `max`.
+
+The kyosei skill itself only dispatches reviewer subagents and posts JSON,
+so it does not need deep reasoning.
+Lowering this level reduces cost and latency without affecting review quality.
+
+Reviewer subagents (code-quality-reviewer, security-reviewer, etc.)
+have their own `effort: high` in agent frontmatter,
+which [overrides the session-level value](https://code.claude.com/docs/en/agents).
+The actual reviews still run at `high` regardless of this setting.
+
+Set to an empty string to omit the flag and use the model default.
+
 ##### `allowed_tools`
 
 Default: see below.

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,17 @@ inputs:
     description: Claude model to use
     required: false
     default: "opus[1m]"
+  effort:
+    description: >-
+      Reasoning effort level for the top-level orchestrator session
+      (low, medium, high, xhigh, max).
+      The kyosei skill itself only dispatches reviewer subagents and posts JSON,
+      so a lower level reduces cost and latency without affecting review quality.
+      Reviewer subagents have their own `effort: high` in agent frontmatter,
+      which overrides this session-level value per Claude Code's agent fields spec.
+      Set to an empty string to omit the flag and use the model default.
+    required: false
+    default: "medium"
   allowed_tools:
     description: >-
       Allowed tools for Claude Code (newline-separated, replaces default set).
@@ -455,6 +466,7 @@ runs:
         show_full_output: ${{ (inputs.show_full_output == 'true' && github.event.repository.private) && 'true' || 'false' }}
         claude_args: >-
           --model "${{ inputs.model }}"
+          ${{ inputs.effort != '' && format('--effort "{0}"', inputs.effort) || '' }}
           --allowed-tools "${{ steps.build-allowed-tools.outputs.joined }}"
           ${{ inputs.claude_args }}
         plugin_marketplaces: ${{ inputs.marketplace_url }}


### PR DESCRIPTION
kyoseiスキルは6つのレビューサブエージェントを起動してJSONを投稿するだけのオーケストレーション役で、
深い思考は不要にもかかわらずシングルスレッドのボトルネックになっていました。
[ncaq/konoka#177](https://github.com/ncaq/konoka/pull/177)で`SKILL.md`に`effort: medium`を入れる方式を試しましたが、
`context: fork`が前提の機能だったため、
[ncaq/konoka#201](https://github.com/ncaq/konoka/issues/201)で発覚した
「forkされたスキルの中から`Task`ツールでサブエージェントを起動できない」問題と一緒に削除されました。

そこでこのアクション側でClaude CLIの`--effort`フラグを通すための`effort`入力を追加します。
デフォルトは`medium`で、空文字列にするとフラグ自体を省略してモデルのデフォルトに任せます。

レビューサブエージェント側の`effort: high`はagent frontmatterの値がセッションレベルを上書きする仕様のため、
[公式ドキュメント](https://code.claude.com/docs/en/agents)どおりレビュー本体は`high`のまま動作します。
バイナリの実装(`KH=H.effort!==void 0?()=>H.effort:q.getEffortValue`)も同じ優先順位を採っており、
オーケストレータだけ軽量化できることを確認しています。

合わせてReusable Workflowと`README.md`にも対応する`effort`項目を追加しました。

close #89
