### PR TITLE
feat: kyoseiが推移的に依存するツールを許可リストに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,23 +335,24 @@ via its Node.js implementation rather than by Claude directly.
 
 ###### GitHub MCP
 
-GitHub MCP tools must be listed individually
-with the full `mcp__github__<tool_name>` form
-(note the trailing `__` separator after "github").
-
-The bare `mcp__github` prefix does NOT match
-claude-code-action's `startsWith("mcp__github__")`
-check that activates the Docker-based GitHub MCP server.
+List each GitHub MCP tool individually as `mcp__github__<tool_name>`,
+because claude-code-action only starts the GitHub MCP server
+when a tool name begins with `mcp__github__`
+(the bare `mcp__github` prefix does not work).
 
 ###### Kyosei skill MCP
 
-The default also allows the tools that the bundled plugins
-(kyosei and its transitive research dependency) rely on,
-including the `Agent` tool and the MCP servers that the research survey agent queries:
+The default also allows what the bundled plugins need:
+the `Agent` tool and the MCP servers used by the research survey agent.
 
-- `mcp__backlog`
+- `mcp__backlog__*` (only the read-only tools the survey agent uses)
 - `mcp__plugin_nix-tasuke_nixos`
 - `mcp__plugin_research_*`
+
+The `mcp__plugin_*` servers ship with the bundled plugins and work out of the box.
+Backlog (`mcp__backlog__*`) is not bundled,
+so it only works if you configure the Backlog MCP server yourself
+(for example via `.mcp.json`).
 
 ##### `additional_allowed_tools`
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,14 @@ The bare `mcp__github` prefix does NOT match
 claude-code-action's `startsWith("mcp__github__")`
 check that activates the Docker-based GitHub MCP server.
 
+The default also allows the tools that the bundled plugins
+(kyosei and its transitive research dependency) rely on,
+including the `Agent` tool and the MCP servers that the research survey agent queries
+
+- `mcp__backlog`
+- `mcp__plugin_nix-tasuke_nixos`
+- `mcp__plugin_research_*`
+
 ##### `additional_allowed_tools`
 
 Default: `""`
@@ -436,63 +444,7 @@ because `runner.environment` is not `self-hosted`.
 
 #### Default allowed tools
 
-```yaml
-allowed_tools: |
-  Bash(awk:*)
-  Bash(gh issue list:*)
-  Bash(gh issue status:*)
-  Bash(gh issue view:*)
-  Bash(gh label list:*)
-  Bash(gh label view:*)
-  Bash(gh pr checks:*)
-  Bash(gh pr diff:*)
-  Bash(gh pr list:*)
-  Bash(gh pr status:*)
-  Bash(gh pr view:*)
-  Bash(gh release list:*)
-  Bash(gh release view:*)
-  Bash(gh repo view:*)
-  Bash(gh ruleset list:*)
-  Bash(gh ruleset view:*)
-  Bash(gh run list:*)
-  Bash(gh run view:*)
-  Bash(gh search:*)
-  Bash(gh status:*)
-  Bash(gh workflow list:*)
-  Bash(gh workflow view:*)
-  Bash(git blame:*)
-  Bash(git cat-file:*)
-  Bash(git describe:*)
-  Bash(git diff:*)
-  Bash(git for-each-ref:*)
-  Bash(git log:*)
-  Bash(git ls-files:*)
-  Bash(git ls-remote:*)
-  Bash(git ls-tree:*)
-  Bash(git rev-list:*)
-  Bash(git rev-parse:*)
-  Bash(git shortlog:*)
-  Bash(git show:*)
-  Bash(git show-branch:*)
-  Bash(git status:*)
-  Bash(jq:*)
-  Bash(node:*)
-  Glob
-  Grep
-  Read
-  Skill
-  Task
-  TodoWrite
-  WebFetch
-  WebSearch
-  mcp__github__get_commit
-  mcp__github__get_file_contents
-  mcp__github__get_issue
-  mcp__github__get_me
-  mcp__github__get_pull_request
-  # ... (all read-only GitHub MCP tools)
-  mcp__github__search_users
-```
+Please see [action.yml](./action.yml) of `allowed_tools` section.
 
 The full list of GitHub MCP tools includes all read-only tools from
 [github-mcp-server](https://github.com/github/github-mcp-server) v0.17.1:
@@ -507,8 +459,6 @@ The full list of GitHub MCP tools includes all read-only tools from
 - Repos
 - Secret
 - Users
-
-See [`action.yml`](action.yml) for the complete list.
 
 To add tools without replacing the defaults, use `additional_allowed_tools`:
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Set to an empty string to omit the flag and use the model default.
 
 ##### `allowed_tools`
 
-Default: see below.
+Default: see the `allowed_tools` default in [action.yml](./action.yml).
 
 Allowed tools for Claude Code (newline-separated, replaces default set).
 Restricted to read-only commands and non-destructive tools.
@@ -348,6 +348,11 @@ the `Agent` tool and the MCP servers used by the research survey agent.
 - `mcp__backlog__*` (only the read-only tools the survey agent uses)
 - `mcp__plugin_nix-tasuke_nixos`
 - `mcp__plugin_research_*`
+
+The `*` here is conceptual shorthand for explanation, not a literal value.
+claude-code-action does not necessarily honor wildcards in `allowed_tools`,
+so the actual default enumerates each tool or server individually
+(for example `mcp__backlog__get_issue` and `mcp__plugin_research_cloudflare`).
 
 The `mcp__plugin_*` servers ship with the bundled plugins and work out of the box.
 Backlog (`mcp__backlog__*`) is not bundled,

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ because `runner.environment` is not `self-hosted`.
 
 #### Default allowed tools
 
-Please see [action.yml](./action.yml) of `allowed_tools` section.
+Please see the `allowed_tools` section of [action.yml](./action.yml).
 
 The full list of GitHub MCP tools includes all read-only tools from
 [github-mcp-server](https://github.com/github/github-mcp-server) v0.17.1:

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ Restricted to read-only commands and non-destructive tools.
 Mutations such as posting reviews are performed by the kyosei skill
 via its Node.js implementation rather than by Claude directly.
 
+###### GitHub MCP
+
 GitHub MCP tools must be listed individually
 with the full `mcp__github__<tool_name>` form
 (note the trailing `__` separator after "github").
@@ -340,6 +342,8 @@ with the full `mcp__github__<tool_name>` form
 The bare `mcp__github` prefix does NOT match
 claude-code-action's `startsWith("mcp__github__")`
 check that activates the Docker-based GitHub MCP server.
+
+###### Kyosei skill MCP
 
 The default also allows the tools that the bundled plugins
 (kyosei and its transitive research dependency) rely on,

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ check that activates the Docker-based GitHub MCP server.
 
 The default also allows the tools that the bundled plugins
 (kyosei and its transitive research dependency) rely on,
-including the `Agent` tool and the MCP servers that the research survey agent queries
+including the `Agent` tool and the MCP servers that the research survey agent queries:
 
 - `mcp__backlog`
 - `mcp__plugin_nix-tasuke_nixos`

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ inputs:
       check that activates the Docker-based GitHub MCP server.
       The default also allows the tools that the bundled plugins
       (kyosei and its transitive research dependency) rely on,
-      including the `Agent` tool and the MCP servers that the research survey agent queries
+      including the `Agent` tool and the MCP servers that the research survey agent queries.
       (`mcp__backlog`, `mcp__plugin_nix-tasuke_nixos`, `mcp__plugin_research_*`)
     required: false
     default: |

--- a/action.yml
+++ b/action.yml
@@ -98,19 +98,19 @@ inputs:
     default: "medium"
   allowed_tools:
     description: >-
-      Allowed tools for Claude Code (newline-separated, replaces default set).
-      Restricted to read-only commands and non-destructive tools.
-      Mutations such as posting reviews are performed by the kyosei skill
-      via its Node.js implementation rather than by Claude directly.
-      GitHub MCP tools must be listed individually with the full `mcp__github__<tool_name>` form
-      (note the trailing `__` separator after "github").
-      The bare `mcp__github` prefix does NOT match
-      claude-code-action's `startsWith("mcp__github__")`
-      check that activates the Docker-based GitHub MCP server.
-      The default also allows the tools that the bundled plugins
-      (kyosei and its transitive research dependency) rely on,
-      including the `Agent` tool and the MCP servers that the research survey agent queries.
-      (`mcp__backlog`, `mcp__plugin_nix-tasuke_nixos`, `mcp__plugin_research_*`)
+      Allowed tools for Claude Code (newline-separated, replaces the default set below).
+      The default is limited to read-only, non-destructive tools;
+      posting reviews is handled by the kyosei skill itself, not directly by Claude.
+      List each GitHub MCP tool individually as `mcp__github__<tool_name>`,
+      because claude-code-action only starts the GitHub MCP server
+      when a tool name begins with `mcp__github__`
+      (the bare `mcp__github` prefix does not work).
+      The default also allows what the bundled plugins need:
+      the `Agent` tool and the MCP servers used by the research survey agent
+      (`mcp__backlog__*`, `mcp__plugin_nix-tasuke_nixos`, `mcp__plugin_research_*`).
+      The `mcp__plugin_*` servers ship with the bundled plugins and work out of the box.
+      Backlog (`mcp__backlog__*`) is not bundled, so it only works
+      if you configure the Backlog MCP server yourself (for example via `.mcp.json`).
     required: false
     default: |
       Agent
@@ -161,7 +161,17 @@ inputs:
       TodoWrite
       WebFetch
       WebSearch
-      mcp__backlog
+      mcp__backlog__get_issue
+      mcp__backlog__get_issue_comments
+      mcp__backlog__get_issues
+      mcp__backlog__get_myself
+      mcp__backlog__get_notifications
+      mcp__backlog__get_project
+      mcp__backlog__get_project_list
+      mcp__backlog__get_pull_request
+      mcp__backlog__get_pull_requests
+      mcp__backlog__get_wiki
+      mcp__backlog__get_wiki_pages
       mcp__github__get_code_scanning_alert
       mcp__github__get_commit
       mcp__github__get_dependabot_alert

--- a/action.yml
+++ b/action.yml
@@ -102,14 +102,18 @@ inputs:
       Restricted to read-only commands and non-destructive tools.
       Mutations such as posting reviews are performed by the kyosei skill
       via its Node.js implementation rather than by Claude directly.
-      GitHub MCP tools must be listed individually
-      with the full `mcp__github__<tool_name>` form
+      GitHub MCP tools must be listed individually with the full `mcp__github__<tool_name>` form
       (note the trailing `__` separator after "github").
       The bare `mcp__github` prefix does NOT match
       claude-code-action's `startsWith("mcp__github__")`
       check that activates the Docker-based GitHub MCP server.
+      The default also allows the tools that the bundled plugins
+      (kyosei and its transitive research dependency) rely on,
+      including the `Agent` tool and the MCP servers that the research survey agent queries
+      (`mcp__backlog`, `mcp__plugin_nix-tasuke_nixos`, `mcp__plugin_research_*`)
     required: false
     default: |
+      Agent
       Bash(awk:*)
       Bash(gh issue list:*)
       Bash(gh issue status:*)
@@ -144,8 +148,8 @@ inputs:
       Bash(git rev-list:*)
       Bash(git rev-parse:*)
       Bash(git shortlog:*)
-      Bash(git show:*)
       Bash(git show-branch:*)
+      Bash(git show:*)
       Bash(git status:*)
       Bash(jq:*)
       Bash(node:*)
@@ -157,6 +161,7 @@ inputs:
       TodoWrite
       WebFetch
       WebSearch
+      mcp__backlog
       mcp__github__get_code_scanning_alert
       mcp__github__get_commit
       mcp__github__get_dependabot_alert
@@ -181,6 +186,7 @@ inputs:
       mcp__github__get_team_members
       mcp__github__get_teams
       mcp__github__get_workflow_run
+      mcp__github__issue_read
       mcp__github__list_branches
       mcp__github__list_code_scanning_alerts
       mcp__github__list_commits
@@ -197,11 +203,18 @@ inputs:
       mcp__github__list_workflow_jobs
       mcp__github__list_workflow_runs
       mcp__github__list_workflows
+      mcp__github__pull_request_read
       mcp__github__search_code
       mcp__github__search_issues
       mcp__github__search_pull_requests
       mcp__github__search_repositories
       mcp__github__search_users
+      mcp__plugin_nix-tasuke_nixos
+      mcp__plugin_research_cloudflare
+      mcp__plugin_research_context7
+      mcp__plugin_research_deepwiki
+      mcp__plugin_research_mdn
+      mcp__plugin_research_microsoft-learn
   additional_allowed_tools:
     description: Additional allowed tools to append to allowed_tools (newline-separated)
     required: false


### PR DESCRIPTION
kyoseiはresearchスキルへ依存しており、
researchはsurveyエージェント経由で各種MCPサーバを参照します。
しかしこれら推移的依存のツールが`allowed_tools`の既定値から漏れていたため、
依存関係調査などでMCPを活用できませんでした。

そこで以下を既定の`allowed_tools`へ追加します。

- `Agent`: researchスキルがsurveyエージェントを起動するために使用します
- `mcp__github__issue_read`, `mcp__github__pull_request_read`:
  各レビューエージェントが参照する新形式のGitHub MCPツールです
- `mcp__backlog`: surveyエージェントが参照します
- `mcp__plugin_nix-tasuke_nixos`, `mcp__plugin_research_*`:
  researchプラグインとその依存が提供するMCPサーバです

明示的なスコープ外で既存の許可に残っているものは、
稀なトラブル時に役立つ可能性があるためそのまま残します。

close #138
