### PR TITLE
feat: GitHub Actionsのデバッグログ有効時に詳細実行情報を表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ Useful for understanding what Claude did during the review.
 `always` enables it regardless of repository visibility.
 `never` disables it entirely.
 `true`/`false` are accepted as aliases for backward compatibility.
+When [GitHub Actions debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging) is enabled (`ACTIONS_STEP_DEBUG`),
+the report is forced on regardless of this value,
+since it only summarizes what Claude did.
 
 ##### `show_full_output`
 
@@ -398,6 +401,9 @@ Default: `false`
 Show full Claude Code JSON output in Actions logs.
 May contain secrets in tool results; use only for debugging.
 Ignored on public repositories to prevent secret leakage.
+When [GitHub Actions debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging) is enabled (`ACTIONS_STEP_DEBUG`),
+the full output is shown automatically,
+but it remains restricted to private repositories.
 
 #### Marketplace and plugin
 

--- a/action.yml
+++ b/action.yml
@@ -415,6 +415,7 @@ runs:
       env:
         DISPLAY_REPORT: ${{ inputs.display_report }}
         IS_PRIVATE: ${{ github.event.repository.private }}
+        RUNNER_DEBUG: ${{ runner.debug }}
       run: |
         # Normalize legacy values.
         case "$DISPLAY_REPORT" in
@@ -428,6 +429,14 @@ runs:
           auto)   enabled="$IS_PRIVATE" ;;
           *)      echo "::error::Unknown display_report value: $DISPLAY_REPORT"; exit 1 ;;
         esac
+        # When GitHub Actions debug logging is enabled
+        # (ACTIONS_STEP_DEBUG=true, surfaced as runner.debug == "1"),
+        # force the report on regardless of repository visibility.
+        # The report only summarizes what Claude did,
+        # so showing it on public repositories is acceptable for debugging.
+        if [[ "$RUNNER_DEBUG" == "1" ]]; then
+          enabled="true"
+        fi
         echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
 
     # Export `$KYOSEI_ACTION_VERSION` via `$GITHUB_ENV`
@@ -490,7 +499,11 @@ runs:
         settings: ${{ inputs.settings }}
         include_fix_links: ${{ inputs.include_fix_links == 'true' && 'true' || 'false' }}
         display_report: ${{ steps.resolve-display-report.outputs.enabled }}
-        show_full_output: ${{ (inputs.show_full_output == 'true' && github.event.repository.private) && 'true' || 'false' }}
+        # Enable full output when explicitly requested,
+        # or when GitHub Actions debug logging is on (runner.debug == "1").
+        # The full trace may contain secrets,
+        # so it stays restricted to private repositories either way.
+        show_full_output: ${{ ((inputs.show_full_output == 'true' || runner.debug == '1') && github.event.repository.private) && 'true' || 'false' }}
         claude_args: >-
           --model "${{ inputs.model }}"
           ${{ inputs.effort != '' && format('--effort "{0}"', inputs.effort) || '' }}


### PR DESCRIPTION
GitHub Actionsのデバッグログ(`ACTIONS_STEP_DEBUG`)を有効にしたとき、
レビューの詳細な実行情報を自動で表示するようにします。
従来は`display_report`と`show_full_output`を個別に指定する必要があり、
デバッグしたいときに設定の手間がかかっていました。

`runner.debug`が`1`のとき以下のように振る舞います。

- `display_report`: 設定値に関わらずレポートを強制的に表示します。
  レポートはClaudeの動作を要約するだけなので、
  パブリックリポジトリで表示しても問題ありません。
- `show_full_output`: フル出力を自動で有効にします。
  ただしフルトレースはシークレットを含む可能性があるため、
  従来通りプライベートリポジトリ限定を維持します。

close #130
