### PR TITLE
refactor: デフォルトモデル名から`[1m]`サフィックスを削除

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -89,7 +89,7 @@ on:
         description: Claude model to use
         type: string
         required: false
-        default: "opus[1m]"
+        default: "opus"
       effort:
         description: >-
           Reasoning effort level for the top-level orchestrator session

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Can configure hooks, env, MCP settings, etc.
 
 ##### `model`
 
-Default: `opus[1m]`
+Default: `opus`
 
 Claude model to use.
 

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ inputs:
   model:
     description: Claude model to use
     required: false
-    default: "opus[1m]"
+    default: "opus"
   effort:
     description: >-
       Reasoning effort level for the top-level orchestrator session


### PR DESCRIPTION
サブスクリプションユーザの環境では1Mコンテキストが自動的に適用される一方、
そうでないユーザに対しては明示的に`[1m]`を指定してしまうと、
意図しない副作用を発生させる可能性があります。
ユーザ側の設定に任せるため、

- `.github/workflows/review.yml`
- `README.md`
- `action.yml`

の3箇所に書かれているデフォルト値を、
`opus[1m]`から`opus`に変更します。
