### PR TITLE
fix: claude-code-actionを`v1.0.145`に固定してレビューが動かない問題を回避します

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -483,7 +483,15 @@ runs:
     - name: Run Kyosei
       id: claude-review
       continue-on-error: true
-      uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1.0.153
+      # claude-code-action`v1.0.146`でagent modeの起動時に
+      # `${RUNNER_TEMP}/claude-prompts`を`rm -rf`するようになった。
+      # <https://github.com/anthropics/claude-code-action/pull/1288>
+      # この変更により後続のWrite user requestステップが書く`claude-user-request.txt`が、
+      # claude-code-action起動時に消去され、
+      # SDK側でスラッシュコマンドを含むマルチブロックメッセージが生成されず、
+      # `/kyosei`が展開されないままClaudeに渡るようになりレビューが動かなくなった。
+      # 暫定対応として直前の`v1.0.145`に固定する。
+      uses: anthropics/claude-code-action@ebcdfe6dc6bb7511eb63e59e07df256dbcf59a2e # v1.0.145
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
       "description": "self-reference; hash is unknown until after merge, and immutable releases make tag pinning safe",
       "matchPackageNames": ["ncaq/kyosei-action"],
       "enabled": false
+    },
+    {
+      "description": "Pin to v1.0.145; v1.0.146 added `rm -rf` of `${RUNNER_TEMP}/claude-prompts` in agent mode (anthropics/claude-code-action#1288), which wipes the `claude-user-request.txt` we write beforehand and breaks `/kyosei` slash command processing. Re-enable once upstream provides a way to inject the user request, or we adopt a different invocation strategy.",
+      "matchPackageNames": ["anthropics/claude-code-action"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
claude-code-actionの`v1.0.146`で導入された、
[anthropics/claude-code-action#1288](https://github.com/anthropics/claude-code-action/pull/1288)
がagent modeの起動時に`${RUNNER_TEMP}/claude-prompts`を`rm -rf`するようになり、
kyosei-actionが事前に書き込んでいる`claude-user-request.txt`が消去されるようになりました。

その結果claude-code-action側のSDKが`claude-user-request.txt`を見つけられず、
スラッシュコマンドを含むマルチブロックメッセージを生成しなくなりました。
`/kyosei <PR_URL>`が展開されないまま`Follow the user request.`だけがClaudeに渡され、
kyoseiスキルが起動せずレビューが一切走らない状態になっていました。

根本解決には上流に修正を入れる必要がありますが、
それまでの暫定対応として、
直前のリリースである`v1.0.145`にバージョンを固定します。
Renovateによる自動更新も同じ理由で無効化し、
解決後に再度有効化できるよう理由を`description`に記載しています。
